### PR TITLE
Fix signal handling

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "singleQuote": true,
+    "editorconfig": true,
+    "trailingComma": "all",
+    "bracketSameLine": true
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,76 +1,13 @@
-import { constants as osConstants } from 'os';
 import { cli } from 'cleye';
 import { version } from '../package.json';
 import { run } from './run';
 import { watchCommand } from './watch';
 import { removeArgvFlags, ignoreAfterArgument } from './remove-argv-flags';
-import { ChildProcess, type Serializable } from 'child_process';
-
-type SignalMessage = Serializable & {
-	type: 'signal';
-	signal: NodeJS.Signals;
-};
-
-// The interval between checks to see if child has acknowledged a signal.
-// Practically speaking, this is the minimum amount to wait before a signal
-// that is sent only to parent will be relayed to child.
-const POLL_INTERVAL_MS = 100;
-// The maximum time to wait to see if child has acknowledged a signal.
-// Practically speaking, if the client is in a tight synchronous loop, or
-// has been stopped in a debugger, then they'll likely get multiple notifications.
-const POLL_MAX_TIME_MS = 1000;
-
-const clientAckTimestamps: { [index: string]: number } = {
-	SIGINT: 0,
-	SIGTERM: 0,
-};
-
-let lastSignal: NodeJS.Signals | null = null;
-
-const handleSignal = (signal: NodeJS.Signals, childProcess: ChildProcess) => {
-	let pending = 0;
-	let timeout: NodeJS.Timeout | null = null;
-	const handle = () => {
-		pending++;
-		lastSignal = signal;
-		const signalTime = Date.now();
-		const maxTime = signalTime + POLL_MAX_TIME_MS;
-		if (timeout != null) clearTimeout(timeout);
-		const notify = () => {
-			const clientAckDelta = (clientAckTimestamps[signal] || 0) - signalTime;
-			if (Math.abs(clientAckDelta) < POLL_MAX_TIME_MS) {
-				// do not notify - client has handled it
-			} else if (Date.now() > maxTime) {
-				// timeout - if we're still spinning, then we need to notify client
-				while (pending > 0) {
-					childProcess.kill(signal);
-					pending--;
-				}
-			} else {
-				timeout = setTimeout(notify, POLL_INTERVAL_MS);
-			}
-		};
-		// no need to wait the very first time
-		timeout = setTimeout(notify, 0);
-	};
-	handle.install = () => process.on(signal, handle);
-	handle.uninstall = () => timeout && clearTimeout(timeout);
-
-	return handle;
-};
-
-const getErrorCode = (
-	childProcess: ChildProcess,
-	defaultCode: number,
-): number => {
-	if (childProcess.exitCode !== null) {
-		return childProcess.exitCode;
-	}
-	if (lastSignal !== null) {
-		return 128 + osConstants.signals[lastSignal];
-	}
-	return defaultCode;
-};
+import {
+	getErrorCode,
+	handleSignal,
+	installClientSignalAckHandler,
+} from './signals';
 
 const tsxFlags = {
 	noCache: {
@@ -112,6 +49,7 @@ cli(
 				description:
 					'Node.js runtime enhanced with esbuild for loading TypeScript & ESM',
 			});
+			// eslint-disable-next-line no-console
 			console.log(`${'-'.repeat(45)}\n`);
 		}
 
@@ -126,20 +64,25 @@ cli(
 		sigint.install();
 		sigterm.install();
 
-		childProcess.on('message', (message: SignalMessage) => {
-			const { type } = message;
-			if (type === 'signal') clientAckTimestamps[message.signal] = Date.now();
-		});
-		childProcess.on('error', (error) => {
+		installClientSignalAckHandler(childProcess);
+
+		const errorListener = (error: Error) => {
+			// eslint-disable-next-line no-console
 			console.error(error);
 			process.exitCode = getErrorCode(childProcess, 1);
+			cleanup();
+		};
+		const exitListener = (code: number | null) => {
+			process.exitCode = getErrorCode(childProcess, code === null ? 0 : code);
+			cleanup();
+		};
+		const cleanup = () => {
 			sigint.uninstall();
 			sigterm.uninstall();
-		});
-		childProcess.on('exit', (error) => {
-			process.exitCode = getErrorCode(childProcess, error === null ? 0 : error);
-			sigint.uninstall();
-			sigterm.uninstall();
-		});
+			process.off('error', errorListener);
+			process.off('exit', exitListener);
+		};
+		childProcess.on('error', errorListener);
+		childProcess.on('exit', exitListener);
 	},
 );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,76 @@
+import { constants as osConstants } from 'os';
 import { cli } from 'cleye';
 import { version } from '../package.json';
 import { run } from './run';
 import { watchCommand } from './watch';
-import {
-	removeArgvFlags,
-	ignoreAfterArgument,
-} from './remove-argv-flags';
+import { removeArgvFlags, ignoreAfterArgument } from './remove-argv-flags';
+import { ChildProcess, type Serializable } from 'child_process';
+
+type SignalMessage = Serializable & {
+	type: 'signal';
+	signal: NodeJS.Signals;
+};
+
+// The interval between checks to see if child has acknowledged a signal.
+// Practically speaking, this is the minimum amount to wait before a signal
+// that is sent only to parent will be relayed to child.
+const POLL_INTERVAL_MS = 100;
+// The maximum time to wait to see if child has acknowledged a signal.
+// Practically speaking, if the client is in a tight synchronous loop, or
+// has been stopped in a debugger, then they'll likely get multiple notifications.
+const POLL_MAX_TIME_MS = 1000;
+
+const clientAckTimestamps: { [index: string]: number } = {
+	SIGINT: 0,
+	SIGTERM: 0,
+};
+
+let lastSignal: NodeJS.Signals | null = null;
+
+const handleSignal = (signal: NodeJS.Signals, childProcess: ChildProcess) => {
+	let pending = 0;
+	let timeout: NodeJS.Timeout | null = null;
+	const handle = () => {
+		pending++;
+		lastSignal = signal;
+		const signalTime = Date.now();
+		const maxTime = signalTime + POLL_MAX_TIME_MS;
+		if (timeout != null) clearTimeout(timeout);
+		const notify = () => {
+			const clientAckDelta = (clientAckTimestamps[signal] || 0) - signalTime;
+			if (Math.abs(clientAckDelta) < POLL_MAX_TIME_MS) {
+				// do not notify - client has handled it
+			} else if (Date.now() > maxTime) {
+				// timeout - if we're still spinning, then we need to notify client
+				while (pending > 0) {
+					childProcess.kill(signal);
+					pending--;
+				}
+			} else {
+				timeout = setTimeout(notify, POLL_INTERVAL_MS);
+			}
+		};
+		// no need to wait the very first time
+		timeout = setTimeout(notify, 0);
+	};
+	handle.install = () => process.on(signal, handle);
+	handle.uninstall = () => timeout && clearTimeout(timeout);
+
+	return handle;
+};
+
+const getErrorCode = (
+	childProcess: ChildProcess,
+	defaultCode: number,
+): number => {
+	if (childProcess.exitCode !== null) {
+		return childProcess.exitCode;
+	}
+	if (lastSignal !== null) {
+		return 128 + osConstants.signals[lastSignal];
+	}
+	return defaultCode;
+};
 
 const tsxFlags = {
 	noCache: {
@@ -18,81 +83,63 @@ const tsxFlags = {
 	},
 };
 
-cli({
-	name: 'tsx',
-	parameters: ['[script path]'],
-	commands: [
-		watchCommand,
-	],
-	flags: {
-		...tsxFlags,
-		version: {
-			type: Boolean,
-			alias: 'v',
-			description: 'Show version',
+cli(
+	{
+		name: 'tsx',
+		parameters: ['[script path]'],
+		commands: [watchCommand],
+		flags: {
+			...tsxFlags,
+			version: {
+				type: Boolean,
+				alias: 'v',
+				description: 'Show version',
+			},
+			help: {
+				type: Boolean,
+				alias: 'h',
+				description: 'Show help',
+			},
 		},
-		help: {
-			type: Boolean,
-			alias: 'h',
-			description: 'Show help',
-		},
+		help: false,
+		ignoreArgv: ignoreAfterArgument(),
 	},
-	help: false,
-	ignoreArgv: ignoreAfterArgument(),
-}, (argv) => {
-	if (argv.flags.version) {
-		process.stdout.write(`tsx v${version}\nnode `);
-	} else if (argv.flags.help) {
-		argv.showHelp({
-			description: 'Node.js runtime enhanced with esbuild for loading TypeScript & ESM',
-		});
-		console.log(`${'-'.repeat(45)}\n`);
-	}
+	(argv) => {
+		if (argv.flags.version) {
+			process.stdout.write(`tsx v${version}\nnode `);
+		} else if (argv.flags.help) {
+			argv.showHelp({
+				description:
+					'Node.js runtime enhanced with esbuild for loading TypeScript & ESM',
+			});
+			console.log(`${'-'.repeat(45)}\n`);
+		}
 
-	const childProcess = run(
-		removeArgvFlags(tsxFlags),
-		{
+		const childProcess = run(removeArgvFlags(tsxFlags), {
 			noCache: Boolean(argv.flags.noCache),
 			tsconfigPath: argv.flags.tsconfig,
-		},
-	);
+		});
 
-	
-	let lastSignal: number;
-	const createRelay = (code: number) => async (signal: NodeJS.Signals) => {
-		lastSignal = code;
-		childProcess.kill(signal);
-	};
-	const signalToRelay = {
-		SIGINT: createRelay(2),
-		SIGTERM: createRelay(15),
-	};
-	for (const [signal, relay] of Object.entries(signalToRelay)) {
-		process.on(signal, relay);
-	}
+		const sigint = handleSignal('SIGINT', childProcess);
+		const sigterm = handleSignal('SIGTERM', childProcess);
 
-	childProcess.on("error", (error) => {
-		if (error) {
+		sigint.install();
+		sigterm.install();
+
+		childProcess.on('message', (message: SignalMessage) => {
+			const { type } = message;
+			if (type === 'signal') clientAckTimestamps[message.signal] = Date.now();
+		});
+		childProcess.on('error', (error) => {
 			console.error(error);
-		}
-		process.exitCode =
-			childProcess.exitCode === null
-				? (128 + lastSignal) || 1
-				: childProcess.exitCode;
-		for (const [signal, relay] of Object.entries(signalToRelay)) {
-			process.off(signal, relay);
-		}
-	});
-	childProcess.on("exit", async (error) => {
-		process.exitCode =
-			error === null
-				? childProcess.exitCode === null
-					? (128 + lastSignal) || 0
-					: childProcess.exitCode
-				: error;
-		for (const [signal, relay] of Object.entries(signalToRelay)) {
-			process.off(signal, relay);
-		}
-	}); 
-	
-});
+			process.exitCode = getErrorCode(childProcess, 1);
+			sigint.uninstall();
+			sigterm.uninstall();
+		});
+		childProcess.on('exit', (error) => {
+			process.exitCode = getErrorCode(childProcess, error === null ? 0 : error);
+			sigint.uninstall();
+			sigterm.uninstall();
+		});
+	},
+);

--- a/src/preflight.cts
+++ b/src/preflight.cts
@@ -13,6 +13,14 @@ import './suppress-warnings.cts';
  */
 require('@esbuild-kit/cjs-loader');
 
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace NodeJS {
+		interface Process {
+			channel: RefCounted;
+		}
+	}
+}
 // If a parent process is detected
 if (process.send) {
 	// Can happen if parent process is disconnected, but most likely
@@ -22,11 +30,12 @@ if (process.send) {
 		// one that is returned, and has already been returned by now.
 		// If this is not performed, the process will continue to run
 		// detached from the parent.
+		// eslint-disable-next-line unicorn/no-process-exit
 		process.exit(1);
 	};
 	process.on('disconnect', exitOnDisconnect);
-	(process as any).channel.unref();
-	
+	process.channel.unref();
+
 	function relay(signal: NodeJS.Signals) {
 		/**
 		 * Since we're setting a custom signal handler, we need to emulate the
@@ -36,6 +45,7 @@ if (process.send) {
 			// eslint-disable-next-line unicorn/no-process-exit
 			process.exit(128 + osConstants.signals[signal]);
 		} else {
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			process.send!({
 				type: 'signal',
 				signal,

--- a/src/preflight.cts
+++ b/src/preflight.cts
@@ -1,3 +1,4 @@
+import { constants as osConstants } from 'os';
 import './suppress-warnings.cts';
 
 /**
@@ -16,15 +17,34 @@ require('@esbuild-kit/cjs-loader');
 if (process.send) {
 	// Can happen if parent process is disconnected, but most likely
 	// it was because parent process was killed via SIGQUIT
-	const exitOnDisconnect = ()=> {
-		// the exit code doesn't matter, as the parent's exit code is the 
-		// one that is returned, and has already been returned by now. 
-		// If this is not performed, the process will continue to run 
-		// detached from the parent. 
+	const exitOnDisconnect = () => {
+		// the exit code doesn't matter, as the parent's exit code is the
+		// one that is returned, and has already been returned by now.
+		// If this is not performed, the process will continue to run
+		// detached from the parent.
 		process.exit(1);
 	};
 	process.on('disconnect', exitOnDisconnect);
-	// adding the disconnect listner on the process will cause this
-	// child process to not exit. 
 	(process as any).channel.unref();
+	
+	function relay(signal: NodeJS.Signals) {
+		/**
+		 * Since we're setting a custom signal handler, we need to emulate the
+		 * default behavior when there are no other handlers set
+		 */
+		if (process.listenerCount(signal) === 1) {
+			// eslint-disable-next-line unicorn/no-process-exit
+			process.exit(128 + osConstants.signals[signal]);
+		} else {
+			process.send!({
+				type: 'signal',
+				signal,
+			});
+		}
+	}
+
+	const relaySignals = ['SIGINT', 'SIGTERM'] as const;
+	for (const signal of relaySignals) {
+		process.on(signal, relay);
+	}
 }

--- a/src/signals.ts
+++ b/src/signals.ts
@@ -1,0 +1,92 @@
+import { constants as osConstants } from 'os';
+import { ChildProcess, type Serializable } from 'child_process';
+
+type SignalMessage = Serializable & {
+	type: 'signal';
+	signal: NodeJS.Signals;
+};
+
+// The interval between checks to see if child has acknowledged a signal.
+// Practically speaking, this is the minimum amount to wait before a signal
+// that is sent only to parent will be relayed to child.
+const POLL_INTERVAL_MS = 100;
+// The maximum time to wait to see if child has acknowledged a signal.
+// Practically speaking, if the client is in a tight synchronous loop, or
+// has been stopped in a debugger, then they'll likely get multiple notifications.
+const POLL_MAX_TIME_MS = 1000;
+
+const clientAckTimestamps: { [index: string]: number } = {
+	SIGINT: 0,
+	SIGTERM: 0,
+};
+
+let lastSignal: NodeJS.Signals | null = null;
+
+export type SignalHandler = {
+	(): void;
+	install(): NodeJS.Process;
+	uninstall(): void;
+};
+export function handleSignal(
+	signal: NodeJS.Signals,
+	childProcess: ChildProcess,
+): SignalHandler {
+	let pending = 0;
+	let timeout: NodeJS.Timeout | null = null;
+	const handle = () => {
+		pending += 1;
+		lastSignal = signal;
+		const signalTime = Date.now();
+		const maxTime = signalTime + POLL_MAX_TIME_MS;
+		if (timeout !== null) {
+			clearTimeout(timeout);
+		}
+		const notify = () => {
+			const clientAckDelta = (clientAckTimestamps[signal] || 0) - signalTime;
+			if (Math.abs(clientAckDelta) < POLL_MAX_TIME_MS) {
+				// do not notify - client has handled it
+			} else if (Date.now() > maxTime) {
+				// timeout - if we're still spinning, then we need to notify client
+				while (pending > 0) {
+					childProcess.kill(signal);
+					pending -= 1;
+				}
+			} else {
+				timeout = setTimeout(notify, POLL_INTERVAL_MS);
+			}
+		};
+		// no need to wait the very first time
+		timeout = setTimeout(notify, 0);
+	};
+	handle.install = () => process.on(signal, handle);
+	handle.uninstall = () => {
+		process.off(signal, handle);
+		if (timeout !== null) {
+			clearTimeout(timeout);
+		}
+	};
+
+	return handle;
+}
+
+export function installClientSignalAckHandler(childProcess: ChildProcess) {
+	childProcess.on('message', (message: SignalMessage) => {
+		const { type } = message;
+		if (type === 'signal') {
+			clientAckTimestamps[message.signal] = Date.now();
+		}
+	});
+}
+
+export function getErrorCode(
+	childProcess: ChildProcess,
+	defaultCode: number,
+): number {
+	if (childProcess.exitCode !== null) {
+		return childProcess.exitCode;
+	}
+	if (lastSignal !== null) {
+		return 128 + osConstants.signals[lastSignal];
+	}
+	return defaultCode;
+}

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -1,20 +1,22 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type { ChildProcess } from 'child_process';
 import { fileURLToPath } from 'url';
-import { constants as osConstants } from 'os';
 import path from 'path';
 import { command } from 'cleye';
 import { watch } from 'chokidar';
 import { run } from '../run';
+import { removeArgvFlags, ignoreAfterArgument } from '../remove-argv-flags';
 import {
-	removeArgvFlags,
-	ignoreAfterArgument,
-} from '../remove-argv-flags';
-import {
-	clearScreen,
-	debounce,
-	isDependencyPath,
-	log,
-} from './utils';
+	type SignalHandler,
+	getErrorCode,
+	handleSignal,
+	installClientSignalAckHandler,
+} from '../signals';
+// eslint-disable-next-line object-curly-newline
+import { clearScreen, debounce, isDependencyPath, log, timeout } from './utils';
+
+const MAX_WAIT_TIME = 5000;
 
 const flags = {
 	noCache: {
@@ -37,116 +39,163 @@ const flags = {
 	},
 } as const;
 
-export const watchCommand = command({
-	name: 'watch',
-	parameters: ['<script path>'],
-	flags,
-	help: {
-		description: 'Run the script and watch for changes',
-	},
+export const watchCommand = command(
+	{
+		name: 'watch',
+		parameters: ['<script path>'],
+		flags,
+		help: {
+			description: 'Run the script and watch for changes',
+		},
 
-	/**
-	 * ignoreAfterArgument needs to parse the first argument
-	 * because cleye will error on missing arguments
-	 *
-	 * Remove once cleye supports error callbacks on missing arguments
-	 */
-	ignoreArgv: ignoreAfterArgument(false),
-}, (argv) => {
-	const rawArgvs = removeArgvFlags(flags, process.argv.slice(3));
-	const options = {
-		noCache: argv.flags.noCache,
-		tsconfigPath: argv.flags.tsconfig,
-		clearScreen: argv.flags.clearScreen,
-		ignore: argv.flags.ignore,
-		ipc: true,
-	};
-
-	let runProcess: ChildProcess | undefined;
-
-	const reRun = debounce(() => {
-		if (
-			runProcess
-			&& (!runProcess.killed && runProcess.exitCode === null)
-		) {
-			runProcess.kill();
-		}
-
-		// Not first run
-		if (runProcess) {
-			log('rerunning');
-		}
-
-		if (options.clearScreen) {
-			process.stdout.write(clearScreen);
-		}
-
-		runProcess = run(rawArgvs, options);
-
-		runProcess.on('message', (data) => {
-			// Collect run-time dependencies to watch
-			if (isDependencyPath(data)) {
-				const dependencyPath = (
-					data.path.startsWith('file:')
-						? fileURLToPath(data.path)
-						: data.path
-				);
-
-				if (path.isAbsolute(dependencyPath)) {
-					// console.log('adding', dependencyPath);
-					watcher.add(dependencyPath);
-				}
-			}
-		});
-	}, 100);
-
-	reRun();
-
-	function exit(signal: NodeJS.Signals) {
 		/**
-		 * In CLI mode where there is only one run, we can inherit the child's exit code.
-		 * But in watch mode, the exit code should reflect the kill signal.
+		 * ignoreAfterArgument needs to parse the first argument
+		 * because cleye will error on missing arguments
+		 *
+		 * Remove once cleye supports error callbacks on missing arguments
 		 */
-		// eslint-disable-next-line unicorn/no-process-exit
-		process.exit(
-			/**
-			 * https://nodejs.org/api/process.html#exit-codes
-			 * >128 Signal Exits: If Node.js receives a fatal signal such as SIGKILL or SIGHUP,
-			 * then its exit code will be 128 plus the value of the signal code. This is a
-			 * standard POSIX practice, since exit codes are defined to be 7-bit integers, and
-			 * signal exits set the high-order bit, and then contain the value of the signal
-			 * code. For example, signal SIGABRT has value 6, so the expected exit code will be
-			 * 128 + 6, or 134.
-			 */
-			128 + osConstants.signals[signal],
-		);
-	}
+		ignoreArgv: ignoreAfterArgument(false),
+	},
+	(argv) => {
+		const rawArgvs = removeArgvFlags(flags, process.argv.slice(3));
+		const options = {
+			noCache: argv.flags.noCache,
+			tsconfigPath: argv.flags.tsconfig,
+			clearScreen: argv.flags.clearScreen,
+			ignore: argv.flags.ignore,
+			ipc: true,
+		};
 
-	function relaySignal(signal: NodeJS.Signals) {
-		// Child is still running
-		if (runProcess && runProcess.exitCode === null) {
-			// Wait for child to exit
-			runProcess.on('close', () => exit(signal));
-			runProcess.kill(signal);
-		} else {
-			exit(signal);
-		}
-	}
+		let runProcess: ChildProcess | undefined;
+		let running = false;
+		let waiting = false;
+		let sigint: SignalHandler;
+		let sigterm: SignalHandler;
+		let errorListener;
+		let exitListener;
 
-	process.once('SIGINT', relaySignal);
-	process.once('SIGTERM', relaySignal);
+		const runner = debounce(async () => {
+			if (waiting) {
+				return;
+			}
+			if (running) {
+				waiting = true;
+				runProcess!.off('error', errorListener!);
+				runProcess!.off('exit', exitListener!);
+				sigint!.uninstall();
+				sigterm!.uninstall();
+				log(
+					`Process running: sending SIGTERM and waiting for up to ${
+						MAX_WAIT_TIME / 1000
+					} seconds...`,
+				);
+				runProcess?.kill('SIGTERM');
+				let listener;
+				const untilProcessExits = new Promise<void>((resolve) => {
+					listener = (code: number | null) => {
+						log(
+							`Process exited with status code: ${getErrorCode(
+								runProcess!,
+								code === null ? 0 : code,
+							)}`,
+						);
+						resolve();
+					};
+					runProcess!.once('exit', listener);
+				});
+				try {
+					await timeout(
+						untilProcessExits,
+						() => runProcess!.off('exit', listener!),
+						MAX_WAIT_TIME,
+					);
+				} catch {
+					log('Timeout: sending SIGKILL');
+					runProcess?.kill('SIGKILL');
+				}
+				running = false;
+				waiting = false;
+			}
+			// Not first run
+			if (runProcess) {
+				log('Running');
+			}
 
-	/**
-	 * Ideally, we can get a list of files loaded from the run above
-	 * and only watch those files, but it's not possible to detect
-	 * the full dependency-tree at run-time because they can be hidden
-	 * in a if-condition/async-delay.
-	 *
-	 * As an alternative, we watch cwd and all run-time dependencies
-	 */
-	const watcher = watch(
-		argv._,
-		{
+			if (options.clearScreen) {
+				process.stdout.write(clearScreen);
+			}
+
+			runProcess = run(rawArgvs, options);
+			running = true;
+			runProcess.on('message', (data) => {
+				// Collect run-time dependencies to watch
+				if (isDependencyPath(data)) {
+					const dependencyPath = data.path.startsWith('file:')
+						? fileURLToPath(data.path)
+						: data.path;
+
+					if (path.isAbsolute(dependencyPath)) {
+						// console.log('adding', dependencyPath);
+						watcher.add(dependencyPath);
+					}
+				}
+			});
+
+			sigint = handleSignal('SIGINT', runProcess);
+			sigterm = handleSignal('SIGTERM', runProcess);
+
+			sigint.install();
+			sigterm.install();
+
+			installClientSignalAckHandler(runProcess);
+
+			errorListener = (error: Error) => {
+				running = false;
+				sigint.uninstall();
+				sigterm.uninstall();
+				// On "Return" key
+				process.stdin.once('data', runner);
+				log(error);
+				if (runProcess !== null) {
+					log(`Process error: ${getErrorCode(runProcess!, 1)}`);
+				} else {
+					log('Process exited. Press enter/return to run again');
+				}
+				log('Press enter/return to run again, or ctrl-C to terminate.');
+			};
+			exitListener = (code: number | null) => {
+				running = false;
+				sigint.uninstall();
+				sigterm.uninstall();
+				// On "Return" key
+				process.stdin.once('data', runner);
+				if (runProcess !== null) {
+					log(
+						`Process exited with status code: ${getErrorCode(
+							runProcess!,
+							code === null ? 0 : code,
+						)}`,
+					);
+				} else {
+					log('Process exited.');
+				}
+				log('Press enter/return to run again, or ctrl-C to terminate.');
+			};
+			runProcess.once('error', errorListener);
+			runProcess.once('exit', exitListener);
+		}, 100);
+
+		runner();
+
+		/**
+		 * Ideally, we can get a list of files loaded from the run above
+		 * and only watch those files, but it's not possible to detect
+		 * the full dependency-tree at run-time because they can be hidden
+		 * in a if-condition/async-delay.
+		 *
+		 * As an alternative, we watch cwd and all run-time dependencies
+		 */
+		const watcher = watch(argv._, {
 			cwd: process.cwd(),
 			ignoreInitial: true,
 			ignored: [
@@ -162,9 +211,6 @@ export const watchCommand = command({
 				...options.ignore,
 			],
 			ignorePermissionErrors: true,
-		},
-	).on('all', reRun);
-
-	// On "Return" key
-	process.stdin.on('data', reRun);
-});
+		}).on('all', runner);
+	},
+);

--- a/src/watch/utils.ts
+++ b/src/watch/utils.ts
@@ -16,14 +16,14 @@ export function debounce(
 	originalFunction: () => void,
 	duration: number,
 ) {
-	let timeout: NodeJS.Timeout | undefined;
+	let timer: NodeJS.Timeout | undefined;
 
 	return () => {
-		if (timeout) {
-			clearTimeout(timeout);
+		if (timer) {
+			clearTimeout(timer);
 		}
 
-		timeout = setTimeout(
+		timer = setTimeout(
 			() => originalFunction(),
 			duration,
 		);
@@ -38,4 +38,27 @@ export function isDependencyPath(
 		&& typeof data === 'object'
 		&& data.type === 'dependency'
 	);
+}
+
+export async function timeout<T>(
+	promise: Promise<T>,
+	cleanup: () => void,
+	time: number,
+): Promise<T> {
+	let timer: NodeJS.Timeout | null = null;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<T>((_resolve, reject) => {
+				timer = setTimeout(reject, time);
+			}),
+		]);
+	} finally {
+		if (timer) {
+			clearTimeout(timer);
+		}
+		if (cleanup) {
+			cleanup();
+		}
+	}
 }

--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -131,8 +131,8 @@ export default testSuite(({ describe }, fixturePath: string) => {
 
 				expect(output).toMatch(
 					process.platform === 'win32'
-						? 'READY\r\nSIGINT\r\nSIGINT\r\nSIGINT HANDLER COMPLETED\r\n'
-						: 'READY\r\n^CSIGINT\r\nSIGINT\r\nSIGINT HANDLER COMPLETED\r\n',
+						? 'READY\r\nSIGINT\r\nSIGINT HANDLER COMPLETED\r\n'
+						: 'READY\r\n^CSIGINT\r\nSIGINT HANDLER COMPLETED\r\n',
 				);
 				expect(output).toMatch(/EXIT_CODE:\s+200/);
 			}, 10_000);

--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -131,8 +131,8 @@ export default testSuite(({ describe }, fixturePath: string) => {
 
 				expect(output).toMatch(
 					process.platform === 'win32'
-						? 'READY\r\nSIGINT\r\nSIGINT HANDLER COMPLETED\r\n'
-						: 'READY\r\n^CSIGINT\r\nSIGINT HANDLER COMPLETED\r\n',
+						? 'READY\r\nSIGINT\r\nSIGINT\r\nSIGINT HANDLER COMPLETED\r\n'
+						: 'READY\r\n^CSIGINT\r\nSIGINT\r\nSIGINT HANDLER COMPLETED\r\n',
 				);
 				expect(output).toMatch(/EXIT_CODE:\s+200/);
 			}, 10_000);


### PR DESCRIPTION
Fixing my own reported issue #252 
Though, this might also for for #253 and issue #201

The problem is that the previous signal handling didn't work properly. Previously, on a SIGINT/SIGTERM signal, the parent would install a message listener, and wait for the childProcess to send a 'kill' IPC message to the parent (and then, it would also exit the process, if there were no other signal listeners installed). The problem is that node will not terminate a process if any open IPC listeners. 

Also, this simplifies the logic a bit. AFIACT, when a signal is sent to a process (using kill), it is sent to all processes of that process group. When a signal is sent via the terminal, it is sent to the child process. 

This commit simplifies the logic such that all signals from the parent are always sent to the child, but the parent also makes a note of which signal this is (for use later.) 

The child does not need to have any special signal handling. By default, SIGINT will return 128+2, and SIGTERM will return 128+15. If a child process chooses to implement their own signal handler - thats fine. That child process can have its own return code that isn't based on signal. If thats the case, it is used. Otherwise, the default exit code will be the 128+signalCode. 

This also supports SIGQUIT of the parent. By default, kill -9 of the parent will just kill the parent, but not the child. This leaves a dandling/orphaned process. To fix this, the clientProcess installs a on('disconnect') listener which will exit the child process when the parent goes away. (Note, this can only be SIGQUIT, since SIGINT/SIGTERM would be relayed to the child, SIGQUIT is the only one that can not be relayed) However, adding 'disconnect' to process will cause the child to prevent the process from existing. So a special `process.channel.unref();` is used to avoid this "leaked listener" from preventing the process to terminate. (https://nodejs.org/api/process.html#processchannelunref) 

This is probably ok. But just calling out a specific gotcha that may affect code that uses their own IPC handler for their own spawned children. preflight is basically imposing that IPC channels will not prevent the process from exiting, which may be unexpected. 

Technically, the entire lines 17-29 in preflight are all optional. They are only used to clean up a zombie process. But since it may cause unexpected behavior in some scripts that use their own IPC, this might need to have a flag. Or maybe just removed completely. 