### PR TITLE
Windows watch globbing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text eol=lf
+*.ts text

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -191,6 +191,7 @@ export const watchCommand = command({
 				...options.ignore,
 			],
 			ignorePermissionErrors: true,
+			disableGlobbing: true,
 		},
 	).on('all', reRun);
 


### PR DESCRIPTION
Fixes #301 - Chokidar has issues specifically on windows with watching paths with globs in the name.

In order to work-around that, the best approach I can find is to add `disableGlobbing` to the chokidar options. Unfortunately, that seems to conflict with #208 - as there is no approach to set disable globbing for certain additions, but keep globbing for others.

In order to reduce conflicts with #208, this one can set up a `disableGlobbing` argument, or the other PR can make it so that if you pass in the `add` flag, it enables globbing - and the user would have to specifically set up globs for any directories with `{` in them.