### PR TITLE
feat: use Node's `--experimental-detect-module`

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -1,7 +1,7 @@
 import type { StdioOptions } from 'child_process';
 import { pathToFileURL } from 'url';
 import spawn from 'cross-spawn';
-import { supportsModuleRegister } from './utils/node-features';
+import { supportsModuleRegister, detectModule } from './utils/node-features';
 
 export function run(
 	argv: string[],
@@ -32,9 +32,14 @@ export function run(
 	return spawn(
 		process.execPath,
 		[
-			'--require',
-			require.resolve('./preflight.cjs'),
-
+			...(
+				detectModule
+					? ['--experimental-detect-module']
+					: [
+						'--require',
+						require.resolve('./preflight.cjs'),
+					]
+			),
 			supportsModuleRegister ? '--import' : '--loader',
 			pathToFileURL(require.resolve('./loader.mjs')).toString(),
 

--- a/src/utils/node-features.ts
+++ b/src/utils/node-features.ts
@@ -18,3 +18,5 @@ export const isolatedLoader = compareNodeVersion([20, 0, 0]) >= 0;
 export const supportsModuleRegister = compareNodeVersion([20, 6, 0]) >= 0;
 
 export const importAttributes = compareNodeVersion([21, 0, 0]) >= 0;
+
+export const detectModule = compareNodeVersion([21, 1, 0]) >= 0;

--- a/tests/specs/smoke.ts
+++ b/tests/specs/smoke.ts
@@ -315,6 +315,7 @@ const files = {
 };
 
 const packageTypes = [
+	undefined,
 	'module',
 	'commonjs',
 ] as const;
@@ -322,9 +323,9 @@ const packageTypes = [
 export default testSuite(async ({ describe }, { tsx }: NodeApis) => {
 	describe('Smoke', ({ describe }) => {
 		for (const packageType of packageTypes) {
-			const isCommonJs = packageType === 'commonjs';
+			const isCommonJs = packageType !== 'module';
 
-			describe(packageType, ({ test, describe }) => {
+			describe(packageType || 'Ambiguious', ({ test, describe }) => {
 				test('from .js', async ({ onTestFinish, onTestFail }) => {
 					const fixture = await createFixture({
 						...files,


### PR DESCRIPTION
This is an experiment to leverage Node's new ESM detection (https://github.com/nodejs/node/pull/50096) to replace the CommonJS loader.

Currently, the tests fail with `require is not defined` so we won't be able to use this (at least without a breaking change).

Seems like Node expects ambiguous ESM files to be written in _strict ESM_ (e.g. no use of `require()`, `__filename`, etc.). In contrast, tsx compiles ESM to CJS (_loose ESM_) so it allows a mix of both ESM and CJS syntax.
