### PR TITLE
refactor: remove source-map-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
 	},
 	"dependencies": {
 		"esbuild": "~0.18.20",
-		"get-tsconfig": "^4.7.2",
-		"source-map-support": "^0.5.21"
+		"get-tsconfig": "^4.7.2"
 	},
 	"optionalDependencies": {
 		"fsevents": "~2.3.3"
@@ -65,7 +64,6 @@
 		"@types/node": "^20.9.0",
 		"@types/react": "^18.2.21",
 		"@types/semver": "^7.5.1",
-		"@types/source-map-support": "^0.5.7",
 		"cachedir": "^2.4.0",
 		"chokidar": "^3.5.3",
 		"clean-pkg-json": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,6 @@ dependencies:
   get-tsconfig:
     specifier: ^4.7.2
     version: 4.7.2
-  source-map-support:
-    specifier: ^0.5.21
-    version: 0.5.21
 
 optionalDependencies:
   fsevents:
@@ -44,9 +41,6 @@ devDependencies:
   '@types/semver':
     specifier: ^7.5.1
     version: 7.5.1
-  '@types/source-map-support':
-    specifier: ^0.5.7
-    version: 0.5.7
   cachedir:
     specifier: ^2.4.0
     version: 2.4.0
@@ -701,12 +695,6 @@ packages:
     resolution: {integrity: sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==}
     dev: true
 
-  /@types/source-map-support@0.5.7:
-    resolution: {integrity: sha512-rJqBfLel8jPuL5MwXxMH2Cdb6D80Snu3YJxDE+VJAmtT04l7j3OA7h+FYXlYDys0WeBVH/MPbExj3B8NCaDw9g==}
-    dependencies:
-      source-map: 0.6.1
-    dev: true
-
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
     dev: true
@@ -1073,10 +1061,6 @@ packages:
     dependencies:
       fill-range: 7.0.1
     dev: true
-
-  /buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-    dev: false
 
   /builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -3845,17 +3829,6 @@ packages:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 4.0.0
     dev: true
-
-  /source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
-    dependencies:
-      buffer-from: 1.1.2
-      source-map: 0.6.1
-    dev: false
-
-  /source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
 
   /spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}

--- a/src/cjs/index.ts
+++ b/src/cjs/index.ts
@@ -73,7 +73,7 @@ const transformer = (
 		// Contains native ESM check
 		const transformed = transformDynamicImport(filePath, code);
 		if (transformed) {
-			code = applySourceMap(transformed, filePath);
+			code = applySourceMap(transformed);
 		}
 	} else if (
 		transformTs
@@ -89,7 +89,7 @@ const transformer = (
 			},
 		);
 
-		code = applySourceMap(transformed, filePath);
+		code = applySourceMap(transformed);
 	}
 
 	module._compile(code, filePath);

--- a/src/esm/loaders.ts
+++ b/src/esm/loaders.ts
@@ -1,4 +1,3 @@
-import type { MessagePort } from 'node:worker_threads';
 import path from 'path';
 import { pathToFileURL, fileURLToPath } from 'url';
 import type {
@@ -37,8 +36,6 @@ type resolve = (
 	recursiveCall?: boolean,
 ) => MaybePromise<ResolveFnOutput>;
 
-let mainThreadPort: MessagePort | undefined;
-
 type SendToParent = (data: {
 	type: 'dependency';
 	path: string;
@@ -52,7 +49,6 @@ export const initialize: InitializeHook = async (data) => {
 	}
 
 	const { port } = data;
-	mainThreadPort = port;
 	sendToParent = port.postMessage.bind(port);
 };
 
@@ -61,7 +57,6 @@ export const initialize: InitializeHook = async (data) => {
  * but it shares a closure with the new load hook
  */
 export const globalPreload: GlobalPreloadHook = ({ port }) => {
-	mainThreadPort = port;
 	sendToParent = port.postMessage.bind(port);
 
 	return `
@@ -298,18 +293,14 @@ export const load: LoadHook = async function (
 
 		return {
 			format: 'module',
-			source: applySourceMap(transformed, url, mainThreadPort),
+			source: applySourceMap(transformed),
 		};
 	}
 
 	if (loaded.format === 'module') {
 		const dynamicImportTransformed = transformDynamicImport(filePath, code);
 		if (dynamicImportTransformed) {
-			loaded.source = applySourceMap(
-				dynamicImportTransformed,
-				url,
-				mainThreadPort,
-			);
+			loaded.source = applySourceMap(dynamicImportTransformed);
 		}
 	}
 

--- a/src/esm/register.ts
+++ b/src/esm/register.ts
@@ -5,7 +5,7 @@ import { installSourceMapSupport } from '../source-map.js';
 export const registerLoader = () => {
 	const { port1, port2 } = new MessageChannel();
 
-	installSourceMapSupport(port1);
+	installSourceMapSupport();
 	if (process.send) {
 		port1.addListener('message', (message) => {
 			if (message.type === 'dependency') {

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -1,22 +1,8 @@
-import type { MessagePort } from 'node:worker_threads';
-import sourceMapSupport, { type UrlAndMap } from 'source-map-support';
-import type { Transformed, SourceMap } from './utils/transform/apply-transformers.js';
-import { isolatedLoader } from './utils/node-features.js';
-
-type PortMessage = {
-	filePath: string;
-	map: SourceMap;
-};
+import type { Transformed } from './utils/transform/apply-transformers.js';
 
 const inlineSourceMapPrefix = '\n//# sourceMappingURL=data:application/json;base64,';
 
-export const installSourceMapSupport = (
-	/**
-	 * To support Node v20 where loaders are executed in its own thread
-	 * https://nodejs.org/docs/latest-v20.x/api/esm.html#globalpreload
-	 */
-	loaderPort?: MessagePort,
-) => {
+export const installSourceMapSupport = () => {
 	const hasNativeSourceMapSupport = (
 		/**
 		 * Check if native source maps are supported by seeing if the API is available
@@ -46,37 +32,5 @@ export const installSourceMapSupport = (
 		);
 	}
 
-	const sourcemaps = new Map<string, SourceMap>();
-
-	sourceMapSupport.install({
-		environment: 'node',
-		retrieveSourceMap(url) {
-			const map = sourcemaps.get(url);
-			return (
-				map
-					? ({ url, map } as unknown as UrlAndMap)
-					: null
-			);
-		},
-	});
-
-	if (isolatedLoader && loaderPort) {
-		loaderPort.addListener(
-			'message',
-			({ filePath, map }: PortMessage) => sourcemaps.set(filePath, map),
-		);
-	}
-
-	return (
-		{ code, map }: Transformed,
-		filePath: string,
-		mainThreadPort?: MessagePort,
-	) => {
-		if (isolatedLoader && mainThreadPort) {
-			mainThreadPort.postMessage({ filePath, map } satisfies PortMessage);
-		} else {
-			sourcemaps.set(filePath, map);
-		}
-		return code;
-	};
+	return ({ code }: Transformed) => code;
 };


### PR DESCRIPTION
`source-map-support` was originally added for source map support in older versions of Node.js. Now it's not necessary.

I was thinking it may still be used in cases where users set their own `Error.prepareStackTrace` (e.g. https://github.com/esbuild-kit/esm-loader/blob/944cde52cfb6f6a72d45a8f0159b68c97468924b/tests/specs/typescript/ts.ts#L36), but I'm not sure if this is common. Will test further with `source-map-support` but I don't believe this is a breaking change.