### PR TITLE
feat(watch): log reason for rerun & improved exit handling

### DIFF
--- a/src/esm/register.ts
+++ b/src/esm/register.ts
@@ -9,10 +9,7 @@ export const registerLoader = () => {
 	if (process.send) {
 		port1.addListener('message', (message) => {
 			if (message.type === 'dependency') {
-				process.send!(message, undefined, undefined, (_error) => {
-					// Errors if the parent process is killed during watch
-					// e.g. reload (via Return) and hit Ctrl+C immediately
-				});
+				process.send!(message);
 			}
 		});
 	}

--- a/src/esm/register.ts
+++ b/src/esm/register.ts
@@ -9,7 +9,10 @@ export const registerLoader = () => {
 	if (process.send) {
 		port1.addListener('message', (message) => {
 			if (message.type === 'dependency') {
-				process.send!(message);
+				process.send!(message, undefined, undefined, (_error) => {
+					// Errors if the parent process is killed during watch
+					// e.g. reload (via Return) and hit Ctrl+C immediately
+				});
 			}
 		});
 	}

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -127,7 +127,7 @@ export const watchCommand = command({
 	};
 
 	const reRun = debounce(async (event?: string, filePath?: string) => {
-		const message = event ? `${event ? lightMagenta(event) : ''}${filePath ? ` in ${lightGreen('./' + filePath)}` : ''}` : '';
+		const message = event ? `${event ? lightMagenta(event) : ''}${filePath ? ` in ${lightGreen(`./${filePath}`)}` : ''}` : '';
 
 		if (waitingChildExit) {
 			log(message, yellow('Process hasn\'t exited. Killing process...'));

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -165,7 +165,6 @@ export const watchCommand = command({
 				runProcess,
 				// Second Ctrl+C force kills
 				waitingChildExit ? 'SIGKILL' : signal,
-				1000,
 			).then(
 				(exitCode) => {
 					process.exit(exitCode ?? 0);

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -127,10 +127,10 @@ export const watchCommand = command({
 	};
 
 	const reRun = debounce(async (event?: string, filePath?: string) => {
-		const message = event ? `${event ? lightMagenta(event) : ''}${filePath ? ` in ${lightGreen(`./${filePath}`)}` : ''}` : '';
+		const reason = event ? `${event ? lightMagenta(event) : ''}${filePath ? ` in ${lightGreen(`./${filePath}`)}` : ''}` : '';
 
 		if (waitingChildExit) {
-			log(message, yellow('Process hasn\'t exited. Killing process...'));
+			log(reason, yellow('Process hasn\'t exited. Killing process...'));
 			runProcess!.kill('SIGKILL');
 			return;
 		}
@@ -139,10 +139,10 @@ export const watchCommand = command({
 		if (runProcess) {
 			// If process still running
 			if (runProcess.exitCode === null) {
-				log(message, yellow('Restarting...'));
+				log(reason, yellow('Restarting...'));
 				await killProcess(runProcess);
 			} else {
-				log(message, yellow('Rerunning...'));
+				log(reason, yellow('Rerunning...'));
 			}
 
 			if (options.clearScreen) {
@@ -161,6 +161,10 @@ export const watchCommand = command({
 
 		// Child is still running, kill it
 		if (runProcess?.exitCode === null) {
+			if (waitingChildExit) {
+				log(yellow('Previous process hasn\'t exited yet. Force killing...'));
+			}
+
 			killProcess(
 				runProcess,
 				// Second Ctrl+C force kills

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -127,7 +127,7 @@ export const watchCommand = command({
 	};
 
 	const reRun = debounce(async (event?: string, filePath?: string) => {
-		const message = event ? `${event ? lightMagenta(event) : ''}${filePath ? ` at ${lightGreen(filePath)}` : ''}` : '';
+		const message = event ? `${event ? lightMagenta(event) : ''}${filePath ? ` in ${lightGreen('./' + filePath)}` : ''}` : '';
 
 		if (waitingChildExit) {
 			log(message, yellow('Process hasn\'t exited. Killing process...'));

--- a/src/watch/utils.ts
+++ b/src/watch/utils.ts
@@ -12,20 +12,21 @@ export const log = (...messages: unknown[]) => console.log(
 // https://github.com/sindresorhus/ansi-escapes/blob/2b3b59c56ff77a/index.js#L80
 export const clearScreen = '\u001Bc';
 
-export function debounce(
-	originalFunction: () => void,
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const debounce = <T extends (this: unknown, ...args: any[]) => void>(
+	originalFunction: T,
 	duration: number,
-) {
+): T => {
 	let timeout: NodeJS.Timeout | undefined;
 
-	return () => {
+	return function () {
 		if (timeout) {
 			clearTimeout(timeout);
 		}
 
 		timeout = setTimeout(
-			() => originalFunction(),
+			() => Reflect.apply(originalFunction, this, arguments),
 			duration,
 		);
-	};
-}
+	} as T;
+};

--- a/tests/specs/watch.ts
+++ b/tests/specs/watch.ts
@@ -62,6 +62,7 @@ export default testSuite(async ({ describe }) => {
 							return true;
 						}
 					},
+					data => data.includes('[tsx] change in ./value.js Rerunning...\n'),
 					data => data.includes('goodbye world\n'),
 				],
 				5000,

--- a/tests/specs/watch.ts
+++ b/tests/specs/watch.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { setTimeout } from 'timers/promises';
 import { testSuite, expect } from 'manten';
 import { createFixture } from 'fs-fixture';
+import stripAnsi from 'strip-ansi';
 import { tsx } from '../utils/tsx.js';
 import { processInteract } from '../utils/process-interact.js';
 
@@ -62,7 +63,7 @@ export default testSuite(async ({ describe }) => {
 							return true;
 						}
 					},
-					data => data.includes('[tsx] change in ./value.js Rerunning...\n'),
+					data => stripAnsi(data).includes('[tsx] change in ./value.js Rerunning...\n'),
 					data => data.includes('goodbye world\n'),
 				],
 				5000,


### PR DESCRIPTION
fix https://github.com/privatenumber/tsx/issues/218

In addition, this improves child process exit handling:
- When a reload is triggered, it sends `SIGTERM` to the child, but if it doesn't exit within 5s, it sends a `SIGKILL`
- When the watcher is exiting (e.g. Ctrl+C), it sends a `SIGKILL` if it doesn't exit within 5s
  - The rationale here is that you're quitting the watcher instead of the process. And it doesn't make sense that the child process can trap the watcher and prevent it from exiting.
- Double Ctrl+C to force quit