### PR TITLE
fix: clarify Node flag claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ _tsx_ wraps around Node.js to enhance it with TypeScript support. Because it's a
 # --no-warnings is a Node.js flag
 tsx --no-warnings ./file.ts
 ```
+> Note: Node flags must go _before_ the file specification. 
 
 ### Run TypeScript / ESM / CJS module
 


### PR DESCRIPTION
This doesn't work:

```
npx tsx foo.ts --tsconfig tsconfig.json --env-file=.env     
```

This does work:

```
 npx tsx --env-file=.env  foo.ts  --tsconfig tsconfig.json
```