### PR TITLE
fix: identify ESM in empty export file

### DIFF
--- a/src/utils/esm-pattern.ts
+++ b/src/utils/esm-pattern.ts
@@ -23,8 +23,8 @@ const esmPattern = /\b(?:import|export)\b/;
 export const isESM = (code: string) => {
 	if (code.includes('import') || code.includes('export')) {
 		try {
-			const [imports, exports] = parseEsm(code);
-			return imports.length > 0 || exports.length > 0;
+			const hasModuleSyntax = parseEsm(code)[3];
+			return hasModuleSyntax;
 		} catch {
 			/**
 			 * If it fails to parse, there's a syntax error

--- a/tests/specs/smoke.ts
+++ b/tests/specs/smoke.ts
@@ -230,7 +230,8 @@ const files = {
 				type: 'module',
 				exports: './index.js',
 			}),
-			'index.js': syntaxLowering,
+			'index.js': syntaxLowering + '\nexport * from "./empty-export.js"',
+			'empty-export.js': 'export {}',
 		},
 	},
 

--- a/tests/specs/smoke.ts
+++ b/tests/specs/smoke.ts
@@ -230,7 +230,7 @@ const files = {
 				type: 'module',
 				exports: './index.js',
 			}),
-			'index.js': syntaxLowering + '\nexport * from "./empty-export.js"',
+			'index.js': `${syntaxLowering}\nexport * from "./empty-export.js"`,
 			'empty-export.js': 'export {}',
 		},
 	},


### PR DESCRIPTION
Previously, `export {}` was not compiled to ESM because no exports were detected. Not it simply checks for ESM syntax.