### PR TITLE
ci(lock-threads): fix yaml syntax

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -15,7 +15,7 @@ jobs:
       discussions: write
 
     steps:
-        uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v5
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '91'


### PR DESCRIPTION
The current syntax for the lock threads job is incorrect. This PR addresses it.

Also, add actionlint to check job syntax as part of the PR workflow.
Finally, format syntax as suggested by actionlint.

Refs: https://github.com/privatenumber/tsx/pull/441