### PR TITLE
docs(VS Code): replaced `workspaceRoot` with `workspaceFolder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Create the following configuration file in your project to setup debugging in VS
 	    Path to tsx binary
 	    Assuming locally installed
 	    */
-	    "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/tsx",
+	    "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tsx",
 
 	    /*
 	    Open terminal when debugging starts (Optional)


### PR DESCRIPTION
The `workspaceRoot` variable is deprecated and replaced with the `workspaceFolder` variable, in reference to Multi-Folder workspaces that don't have a root

https://code.visualstudio.com/docs/editor/variables-reference#_why-isnt-workspaceroot-documented