### PR TITLE
fix: Remove the pipe file before starting the ipc server

### DIFF
--- a/src/utils/ipc/server.ts
+++ b/src/utils/ipc/server.ts
@@ -36,6 +36,20 @@ export const createIpcServer = async () => {
 	const pipePath = getPipePath(process.pid);
 	await fs.promises.mkdir(tmpdir, { recursive: true });
 
+	/**
+	 * Fix #457 (https://github.com/privatenumber/tsx/issues/457)
+	 *
+	 * Avoid the error "EADDRINUSE: address already in use"
+	 *
+	 * If the pipe file already exists, it means that the previous process has been closed abnormally.
+	 *
+	 * We can safely delete the pipe file, the previous process must has been closed,
+	 * as pid is unique at the same.
+	 */
+	if (fs.existsSync(pipePath)) {
+		await fs.promises.rm(pipePath);
+	}
+
 	await new Promise<void>((resolve, reject) => {
 		server.listen(pipePath, resolve);
 		server.on('error', reject);


### PR DESCRIPTION
Fix #457

@horvbalint might suggest uuid for avoiding the issue. 

But I think the solution can be simpler. Since the pid is unique, which means there are no running processes with the same pid at the same time. If the pipe file exists, it must be a dead process. So we can delete it directly to fix the issue.

I can another branch to prove the fix:
https://github.com/louislam/tsx-issue-reproduce/tree/test-fix

Here is the docker logs:
https://github.com/louislam/tsx-issue-reproduce/actions/runs/7596779067/job/20690886488