### PR TITLE
fix: escape `import.meta.url` passed to esbuild

### DIFF
--- a/src/utils/transform/index.ts
+++ b/src/utils/transform/index.ts
@@ -46,7 +46,7 @@ export function transformSync(
 	const define: { [key: string]: string } = {};
 
 	if (!(filePath.endsWith('.cjs') || filePath.endsWith('.cts'))) {
-		define['import.meta.url'] = `'${pathToFileURL(filePath)}'`;
+		define['import.meta.url'] = JSON.stringify(pathToFileURL(filePath));
 	}
 
 	const esbuildOptions = {

--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -63,6 +63,38 @@ export default testSuite(({ describe }, node: NodeApis) => {
 					expect(tsxProcess.stderr).toBe('');
 				});
 			});
+
+			describe('paths', async () => {
+				test('normal path', async ({ onTestFinish }) => {
+					const fixture = await createFixture({
+						'normal_name.ts': 'console.log(JSON.stringify(process.argv) as string)',
+					});
+					onTestFinish(async () => await fixture.rm());
+
+					const tsxProcess = await tsx([
+						path.join(fixture.path, 'normal_name.ts'),
+					]);
+
+					expect(tsxProcess.exitCode).toBe(0);
+					expect(tsxProcess.stderr).toBe('');
+					expect(tsxProcess.failed).toBe(false);
+				});
+
+				test('path with \'-\'', async ({ onTestFinish }) => {
+					const fixture = await createFixture({
+						'weird \'-\' name.ts': 'console.log(JSON.stringify(process.argv) as string)',
+					});
+					onTestFinish(async () => await fixture.rm());
+
+					const tsxProcess = await tsx([
+						path.join(fixture.path, 'weird \'-\' name.ts'),
+					]);
+
+					expect(tsxProcess.exitCode).toBe(0);
+					expect(tsxProcess.stderr).not.toContain('[esbuild Error]: Invalid define value (must be an entity name or valid JSON syntax)');
+					expect(tsxProcess.failed).toBe(false);
+				});
+			});
 		});
 
 		describe('eval & print', ({ test }) => {

--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -63,38 +63,6 @@ export default testSuite(({ describe }, node: NodeApis) => {
 					expect(tsxProcess.stderr).toBe('');
 				});
 			});
-
-			describe('paths', async () => {
-				test('normal path', async ({ onTestFinish }) => {
-					const fixture = await createFixture({
-						'normal_name.ts': 'console.log(JSON.stringify(process.argv) as string)',
-					});
-					onTestFinish(async () => await fixture.rm());
-
-					const tsxProcess = await tsx([
-						path.join(fixture.path, 'normal_name.ts'),
-					]);
-
-					expect(tsxProcess.exitCode).toBe(0);
-					expect(tsxProcess.stderr).toBe('');
-					expect(tsxProcess.failed).toBe(false);
-				});
-
-				test('path with \'-\'', async ({ onTestFinish }) => {
-					const fixture = await createFixture({
-						'weird \'-\' name.ts': 'console.log(JSON.stringify(process.argv) as string)',
-					});
-					onTestFinish(async () => await fixture.rm());
-
-					const tsxProcess = await tsx([
-						path.join(fixture.path, 'weird \'-\' name.ts'),
-					]);
-
-					expect(tsxProcess.exitCode).toBe(0);
-					expect(tsxProcess.stderr).not.toContain('[esbuild Error]: Invalid define value (must be an entity name or valid JSON syntax)');
-					expect(tsxProcess.failed).toBe(false);
-				});
-			});
 		});
 
 		describe('eval & print', ({ test }) => {


### PR DESCRIPTION
Closes #473 

When path had a single quote it was breaking the path passed to esbuild.

Added passing tests. 
Locally using node from nvmrc there were 3 tests not passing.
But passing in node v18.15.0

