### PR TITLE
fix: resolve tsconfig paths inside node_modules

### DIFF
--- a/src/esm/loaders.ts
+++ b/src/esm/loaders.ts
@@ -152,7 +152,8 @@ export const resolve: resolve = async function (
 	if (
 		tsconfigPathsMatcher
 		&& !isPath // bare specifier
-		&& !context.parentURL?.includes('/node_modules/')
+		// https://github.com/privatenumber/tsx/issues/159
+		// && !context.parentURL?.includes('/node_modules/')
 	) {
 		const possiblePaths = tsconfigPathsMatcher(specifier);
 		for (const possiblePath of possiblePaths) {


### PR DESCRIPTION
fix #159

I commented out the lines regarding `node_modules` detection. Already tested in my environment.

However I'm not sure what the original intention of this line of code is (performance concern?), or whether it breaks anything else.
