### PR TITLE
document `require('tsx/cjs')` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,14 @@ If you only need to add TypeScript & ESM support in a CommonJS context, you can 
 node --require tsx/cjs ./file.ts
 ```
 
+You can also `require` the CJS loader from a commonjs script, enabling you to use typescript modules from that script:
+
+```js
+require('tsx/cjs')
+
+module.exports = require('./src/foo.ts')
+```
+
 ### Hashbang
 
 If you prefer to write scripts that doesn't need to be passed into tsx, you can declare it in the [hashbang](https://bash.cyberciti.biz/guide/Shebang).


### PR DESCRIPTION
Hi - I've been gradually moving over from ts-node, and one scenario I noticed wasn't in the readme was an equivalent to `require('ts-node/register'). Useful when you need to use typescript modules from a commonjs script. For example, for a CLI tool like ESLint that doesn't support typescript configs. You can write an [eslint.config.js](https://eslint.org/docs/latest/use/configure/configuration-files-new#configuration-file) like this:

```js
require('tsx/cjs')

module.exports = [
  require('./src/config1.ts'),
  require('./src/config2.ts'),
]
```

This is much easier than figuring out have to run eslint via tsx or pass in a `--require` CLI argument. You can just run `./node_modules/.bin/eslint` normally.