### PR TITLE
docs: Add example for hashbang with local tsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,15 @@ $ ./file.ts hello
 argv: [ 'hello' ]
 ```
 
+If you prefer to use a local `tsx` instead of the global one, you can use `npx`:
+
+_file.ts_
+```ts
+#!/usr/bin/env npx tsx
+
+console.log('argv:', process.argv.slice(2))
+```
+
 ### VS Code debugging
 
 #### Setup


### PR DESCRIPTION
There is also a [variant](https://stackoverflow.com/a/52979955/808699) with `-S`:

```bash
#!/usr/bin/env -S npx tsx
```

but as per my testing using BSD and GNU `env`, the two variants work exactly the same, so I guess without the `-S` would be slightly more portable.