### PR TITLE
docs: fix hashbang example for linux env command

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ If you prefer to use a local `tsx` instead of the global one, you can use `npx`:
 
 _file.ts_
 ```ts
-#!/usr/bin/env npx tsx
+#!/usr/bin/env -S npx tsx
 
 console.log('argv:', process.argv.slice(2))
 ```


### PR DESCRIPTION
Turns out there is a behaviour difference in the GNU `env` tool between MacOS and Linux where the latter does require `-S` for it to work. I've confirmed this working now with:

- env (GNU coreutils) 9.5 on MacOS 14
- env (GNU coreutils) 9.5 on Arch Linux
- env (BSD) on MacOS 14

I posted this as an answer one https://stackoverflow.com/questions/55777677. Also see https://github.com/TypeStrong/ts-node/issues/639#issuecomment-538984217 for similar solution.