### PR TITLE
chore: add `packageManager` field to for explicit pnpm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 9
           run_install: true
 
       - name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
-        with:
-          version: 9
 
       - name: Get pnpm store directory
         shell: bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "tsx",
 	"version": "0.0.0-semantic-release",
+	"packageManager": "pnpm@9.1.0",
 	"description": "TypeScript Execute (tsx): Node.js enhanced with esbuild to run TypeScript & ESM files",
 	"keywords": [
 		"cli",


### PR DESCRIPTION
This would allow contributors to have the exactly same version of pnpm (with corepack enabled).

Also the pnpm setup action will read that field, so we have a single source of the pnpm versions