### PR TITLE
chore: update `gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ yarn-error.log*
 lerna-debug.log*
 
 # Dependency directories
-/node_modules/
+node_modules
 
 # Output of 'npm pack'
 *.tgz


### PR DESCRIPTION
Not sure if it's only me, but I got these in the git status:

<img width="459" alt="Screenshot 2024-05-12 at 19 32 24" src="https://github.com/privatenumber/tsx/assets/11247099/2b2fc16c-1c66-43f3-9ea9-3dc58e55ec7b">
