### PR TITLE
fix: expose types for `esm/api`

### DIFF
--- a/src/esm/api/index.ts
+++ b/src/esm/api/index.ts
@@ -1,2 +1,10 @@
-export { register } from './register.js';
+export {
+	register,
+	type InitializationOptions,
+	type NamespacedUnregister,
+	type Register,
+	type RegisterOptions,
+	type ScopedImport,
+	type Unregister,
+} from './register.js';
 export { tsImport } from './ts-import.js';

--- a/src/esm/api/index.ts
+++ b/src/esm/api/index.ts
@@ -4,7 +4,7 @@ export {
 	type NamespacedUnregister,
 	type Register,
 	type RegisterOptions,
-	type ScopedImport,
 	type Unregister,
 } from './register.js';
+export type { ScopedImport } from './scoped-import.js';
 export { tsImport } from './ts-import.js';

--- a/src/esm/api/register.ts
+++ b/src/esm/api/register.ts
@@ -3,26 +3,28 @@ import { MessageChannel, type MessagePort } from 'node:worker_threads';
 import type { Message } from '../types.js';
 import { createScopedImport, type ScopedImport } from './scoped-import.js';
 
+export type { ScopedImport } from './scoped-import.js';
+
 export type InitializationOptions = {
 	namespace?: string;
 	port?: MessagePort;
 };
 
-type Options = {
+export type RegisterOptions = {
 	namespace?: string;
 	onImport?: (url: string) => void;
 };
 
-type Unregister = () => Promise<void>;
-type Register = {
-	(options: {
-		namespace: string;
-		onImport?: (url: string) => void;
-	}): Unregister & {
-		import: ScopedImport;
-		unregister: Unregister;
-	};
-	(options?: Options): Unregister;
+export type NamespacedRegister = {
+	import: ScopedImport;
+	unregister: Unregister;
+}
+
+export type Unregister = () => Promise<void>;
+
+export type Register = {
+	(options: RegisterOptions & Pick<Required<RegisterOptions>, 'namespace'>): Unregister & NamespacedRegister
+	(options?: RegisterOptions): Unregister;
 };
 
 export const register: Register = (

--- a/src/esm/api/register.ts
+++ b/src/esm/api/register.ts
@@ -3,8 +3,6 @@ import { MessageChannel, type MessagePort } from 'node:worker_threads';
 import type { Message } from '../types.js';
 import { createScopedImport, type ScopedImport } from './scoped-import.js';
 
-export type { ScopedImport } from './scoped-import.js';
-
 export type InitializationOptions = {
 	namespace?: string;
 	port?: MessagePort;
@@ -22,8 +20,10 @@ export type NamespacedUnregister = Unregister & {
 	unregister: Unregister;
 };
 
+type RequiredProperty<Type, Keys extends keyof Type> = Type & { [P in Keys]-?: Type[P] };
+
 export type Register = {
-	(options: RegisterOptions & Pick<Required<RegisterOptions>, 'namespace'>): NamespacedUnregister;
+	(options: RequiredProperty<RegisterOptions, 'namespace'>): NamespacedUnregister;
 	(options?: RegisterOptions): Unregister;
 };
 

--- a/src/esm/api/register.ts
+++ b/src/esm/api/register.ts
@@ -15,15 +15,15 @@ export type RegisterOptions = {
 	onImport?: (url: string) => void;
 };
 
-export type NamespacedRegister = {
-	import: ScopedImport;
-	unregister: Unregister;
-}
-
 export type Unregister = () => Promise<void>;
 
+export type NamespacedUnregister = Unregister & {
+	import: ScopedImport;
+	unregister: Unregister;
+};
+
 export type Register = {
-	(options: RegisterOptions & Pick<Required<RegisterOptions>, 'namespace'>): Unregister & NamespacedRegister
+	(options: RegisterOptions & Pick<Required<RegisterOptions>, 'namespace'>): NamespacedUnregister;
 	(options?: RegisterOptions): Unregister;
 };
 


### PR DESCRIPTION
I was using `ReturnType<typeof register>` to get the type - which I wasn't able to get the overloads with namespaced one. I think it would be nice to expose them.