### PR TITLE
docs: Add contribution guide entrance and tips for `node-pty` installation failure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,10 @@ nvm i      # Install or use Node.js version
 pnpm i     # Install dependencies
 ```
 
+> [!TIP]
+>
+> If you encounter issues with the `node-pty` installation, please ensure you have installed the required build dependencies (listed on the [node-pty GitHub page](https://github.com/microsoft/node-pty?tab=readme-ov-file#dependencies)) before retrying the installation command.
+
 ### Building
 
 Build the source code with:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ tsx
 <p align="center">
 TypeScript Execute (tsx): The easiest way to run TypeScript in Node.js
 <br><br>
-<a href="https://tsx.is">Documentation</a>&nbsp;&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://tsx.is/getting-started">Getting started →</a>
+<a href="https://tsx.is">Documentation</a>&nbsp;&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/privatenumber/tsx/blob/master/CONTRIBUTING.md">Contribution guide</a>&nbsp;&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://tsx.is/getting-started">Getting started →</a>
 </p>
 
 <br>


### PR DESCRIPTION
### Add contribution guide entrance

<img width="759" alt="图片" src="https://github.com/privatenumber/tsx/assets/6831013/d5667dd2-7ca7-4baa-8b5e-eb2980bb5205">

### Add tips for `node-pty` installation failure

<img width="1080" alt="图片" src="https://github.com/privatenumber/tsx/assets/6831013/569d6286-2358-47e4-86de-dc4ee50963d0">
