### PR TITLE
fix(cjs/api): resolve correct module and types when imported

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,14 @@
 		".": "./dist/loader.mjs",
 		"./cjs": "./dist/cjs/index.cjs",
 		"./cjs/api": {
-			"types": "./dist/cjs/api/index.d.cts",
-			"default": "./dist/cjs/api/index.cjs"
+			"import": {
+				"types": "./dist/cjs/api/index.d.mts",
+				"default": "./dist/cjs/api/index.mjs"
+			},
+			"require": {
+				"types": "./dist/cjs/api/index.d.cts",
+				"default": "./dist/cjs/api/index.cjs"
+			}
 		},
 		"./esm": "./dist/esm/index.mjs",
 		"./esm/api": {


### PR DESCRIPTION
Currently the resolved types for `tsx/cjs/api` are broken/wrong for some `moduleResolution`s. Also, resolve to `dist/cjs/api/index.mjs` when `import`ed.

<img width="1079" alt="image" src="https://github.com/privatenumber/tsx/assets/40380293/822338fe-fc83-42f9-9ffe-3885de59f299">

