### PR TITLE
build: disable minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 	},
 	"scripts": {
 		"prepare": "pnpm simple-git-hooks",
-		"build": "pkgroll --minify",
+		"build": "pkgroll",
 		"lint": "lintroll --node --cache .",
 		"type-check": "tsc",
 		"test": "pnpm build && node ./dist/cli.mjs tests/index.ts",


### PR DESCRIPTION
There seems to be little need for minification, as this is a `node` based project never intended to be run in browsers. My reason to get rid of it would be to enable the usage of tools like `patch-package` on the library, which operate on the distributed source, and is practically incompatible with `tsx` in its current state.