### PR TITLE
fix: minimum Node version in warning for `module.register()`

### DIFF
--- a/src/esm/api/register.ts
+++ b/src/esm/api/register.ts
@@ -37,7 +37,7 @@ export const register: Register = (
 	options,
 ) => {
 	if (!module.register) {
-		throw new Error(`This version of Node.js (${process.version}) does not support module.register(). Please upgrade to Node v18.9 or v20.6 and above.`);
+		throw new Error(`This version of Node.js (${process.version}) does not support module.register(). Please upgrade to Node v18.19 or v20.6 and above.`);
 	}
 
 	if (!cjsInteropApplied) {


### PR DESCRIPTION
According to https://nodejs.org/api/module.html#moduleregisterspecifier-parenturl-options
Module.register was Added in: v20.6.0, v18.19.0