### PR TITLE
chore: remove unused `eslintConfig`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,11 @@
+// @ts-check
+import { defineConfig, pvtnbr } from 'lintroll';
+
+export default defineConfig([
+	{
+		ignores: ['tests/fixtures'],
+	},
+	...pvtnbr({
+		node: true,
+	}),
+]);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,0 @@
-// @ts-check
-import { pvtnbr } from 'lintroll';
-
-export default pvtnbr({ node: true });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,11 +1,4 @@
 // @ts-check
-import { defineConfig, pvtnbr } from 'lintroll';
+import { pvtnbr } from 'lintroll';
 
-export default defineConfig([
-	{
-		ignores: ['tests/fixtures'],
-	},
-	...pvtnbr({
-		node: true,
-	}),
-]);
+export default pvtnbr({ node: true });

--- a/package.json
+++ b/package.json
@@ -115,11 +115,5 @@
 		"type-fest": "^4.20.1",
 		"type-flag": "^3.0.0",
 		"typescript": "^5.5.2"
-	},
-	"eslintConfig": {
-		"extends": "@pvtnbr",
-		"ignorePatterns": [
-			"tests/fixtures"
-		]
 	}
 }


### PR DESCRIPTION
Putting the ESLint config in `eslint.config.js` makes it discoverable by editor integrations so that they can show lint errors/fixes inline.

AFAICT `lintroll` completely ignores the `eslintConfig` property in `package.json`, so it already wasn't necessary (and there wasn't a `@pvtnbr/*` package installed to begin with). The ignore of `tests/fixtures`, despite being ignored in the first place, also just isn't necessary.