### PR TITLE
Add --on-return-key flag to conditionally enable Return key listener

### DIFF
--- a/docs/watch-mode.md
+++ b/docs/watch-mode.md
@@ -39,5 +39,5 @@ tsx watch --ignore "./data/**/*" ./file.ts
 
 ## Tips
 
-- Press <kbd>Return</kbd> to manually rerun the script.
+- Press <kbd>Return</kbd> to manually rerun the script. Use `--clear-screen=false` to prevent the screen from clearing on rerun.
 - Use `--clear-screen=false` to prevent the screen from clearing on rerun.

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -36,6 +36,11 @@ const flags = {
 		type: [String],
 		description: 'Paths & globs to exclude from being watched',
 	},
+	onReturnKey: {
+		type: Boolean,
+		description: 'Trigger re-run on Return key press',
+		default: true,
+	},
 } as const;
 
 export const watchCommand = command({
@@ -216,5 +221,6 @@ export const watchCommand = command({
 	).on('all', reRun);
 
 	// On "Return" key
-	process.stdin.on('data', () => reRun('Return key'));
+	if (argv.flags.onReturnKey)
+		process.stdin.on('data', () => reRun('Return key'));
 });


### PR DESCRIPTION
Add --on-return-key flag to conditionally enable Return key listener

- Added `--on-return-key` flag to the `watch` command for optional Return key press handling.
- Updated the command logic to conditionally register `process.stdin.on('data')` listener based on the flag.
- Improved flag description and default behavior in the command configuration.
- Note: Enabling `--on-return-key` may cause issues with `concurrently "tsx watch some.ts"` when `some.ts` imports/require `process`. Specifically, if `some.ts` includes `import mysql from "mysql2"` and `console.log(mysql)`, it may block execution at the `import` statement and not correctly print the content. 
  - You can temporarily resolve this issue by using `concurrently -r`.

This change allows users to control whether the script should trigger a re-run on Return key press, providing more flexibility in how the `watch` command operates.

---

Below is an example demonstrating why the `onReturnKey` parameter is needed.

Create `1.js`:

```js
console.log(1)

require('process')

console.log(2)
```

Create `2.js`:

```js
const { spawn } = require('child_process')

spawn('node', ['1.js'], {
    stdio: ['inherit', 'inherit', 'inherit'],
    shell: true
})
process.stdin.on('data', () => {
    console.log('log in 2.js')
})
```

Create `3.js`:

```js
const { spawn } = require('child_process')

const child = spawn('node', ['2.js'], {
    stdio: ['pipe', 'pipe', 'pipe'],
    shell: true
})
child.stdout.on('data', chunk => {
    console.log(chunk.toString())
})
```

Here are the execution results:

Running `1.js`:

```bash
> node 1.js
1
2
(program ends)
```

Running `2.js`:

```bash
> node 2.js
1
2
(waiting for input) aaaaa
log in 2.js
bbbbb
log in 2.js
ccccc
log in 2.js
ddddd
log in 2.js
(waiting for input)
```

Running `3.js`:

```bash
node 3.js
1
(there is an extra blank line here)
(blocked, unable to input, Enter has no effect)
```

## Analysis

- Running `1.js` and `2.js` both output correctly.
- The `process.stdin.on('data',)` event causes `2.js` to enter a waiting input blocking state after printing.
- When running `node 3.js`, the terminal only outputs `1` and not `2`, indicating that execution is stuck at `require('process')` in `1.js`, and the subsequent code does not execute.
- Any of the following three actions allow all three files to execute normally:
    - Remove `process.stdin.on('data',)` from `2.js`
    - Remove `require("process")` from `1.js`
    - Change `stdio` in `3.js` to `['inherit', 'inherit', 'inherit']` and remove `process.stdin.on('data',)`
- `tsx watch` also uses `process.stdin.on('data',)` ([src/watch/index.ts#L219](https://github.com/privatenumber/tsx/blob/bd83d3bf59e39767ec64eec86fe5b48a8e50b991/src/watch/index.ts#L219)), which is why `concurrently "tsx watch xxx.ts"` will cause `xxx.ts` and all its imported modules to be stuck at the `require("process")` line, with subsequent code not executing.
- So, what is the underlying reason for this?