### PR TITLE
fix: Drop default excludes that are exist in includes

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"node": ">=18.0.0"
 	},
 	"dependencies": {
+		"anymatch": "^3.1.3",
 		"esbuild": "~0.23.0",
 		"get-tsconfig": "^4.7.5"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      anymatch:
+        specifier: ^3.1.3
+        version: 3.1.3
       esbuild:
         specifier: ~0.23.0
         version: 0.23.0
@@ -2037,6 +2040,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-cache-dir@6.0.0:
     resolution: {integrity: sha512-UOwXU6ulg3VQsSyKf0QAVcW4EFq3hFehFHV/ne76iQ9FAw4ZpXHXsmw8AwUueGI13y4apVML/Pb+njilLn/RCw==}
@@ -2151,6 +2155,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3041,6 +3046,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup@4.17.1:


### PR DESCRIPTION
Preserves the intention of users that explicitly specify an included path that may exist in the default excludes list.

For example, the following command should trigger a re-run for any changes in node_modules/linked-dependency, despite node_modules appearing in the default excludes.

```bash
tsx watch --include "node_modules/linked-dependency/**/*" src/index.ts
```