### PR TITLE
feat(esbuild): make it possible to set `keepNames` with `TSX_ESBUILD_KEEP_NAMES`

### DIFF
--- a/src/utils/transform/get-esbuild-options.ts
+++ b/src/utils/transform/get-esbuild-options.ts
@@ -39,7 +39,7 @@ export const cacheConfig = {
 	 * esbuild renames variables even if minification is not enabled
 	 * https://esbuild.github.io/try/#dAAwLjE5LjUAAGNvbnN0IGEgPSAxOwooZnVuY3Rpb24gYSgpIHt9KTs
 	 */
-	keepNames: true,
+	keepNames: process.env.TSX_ESBUILD_KEEP_NAMES !== 'false',
 };
 
 export const patchOptions = (


### PR DESCRIPTION
Hey! Thanks for the really cool project :sparkles: 

I've run into an issue with `tsx` where I'm using it with puppeteer and I get a crash because `__names` is not defined.

It essentially boils down to this code:

```ts
const result = await page.evaluate(() => {
  function func() {}
});
```

getting turned into this by `esbuild` under `keepNames: true`:

```js
const result = await page.evaluate(() => {
  function func() {
  }
  __name(func, "func");
});
```

the issue is that `__name` is not defined in the page and so this errors.

[See this playground](https://esbuild.github.io/try/#dAAwLjI0LjAAewogIHBsYXRmb3JtOiAnbm9kZScsCiAga2VlcE5hbWVzOiB0cnVlLAogIGxvYWRlcjogJ3RzJywKfQBpbXBvcnQgKiBhcyBwdXBwZXRlZXIgZnJvbSAncHVwcGV0ZWVyJzsKCmNvbnN0IGJyb3dzZXIgPSBhd2FpdCBwdXBwZXRlZXIubGF1bmNoKCk7CmNvbnN0IHBhZ2UgPSBhd2FpdCBicm93c2VyLm5ld1BhZ2UoKTsKCi8vIC4uLgoKY29uc3QgcmVzdWx0ID0gYXdhaXQgcGFnZS5ldmFsdWF0ZSgoKSA9PiB7CiAgZnVuY3Rpb24gZnVuYygpIHt9Cn0pOw)

Given that I have no use for `keepNames: true` in my project, it would be nice if `tsx` allowed one to opt-out from `keepNames: true` via an environment variable.

Thus this PR. Let me know what you think! :smiley: 