### PR TITLE
Update node-enhancement.md for test runner support

### DIFF
--- a/docs/node-enhancement.md
+++ b/docs/node-enhancement.md
@@ -43,6 +43,9 @@ The [Node.js REPL](https://nodejs.org/en/learn/command-line/how-to-use-the-nodej
 
 ## Test runner
 
+::: Available in Node.js v21 and above
+:::
+
 _tsx_ enhances the Node.js built-in [test runner](https://nodejs.org/api/test.html) with TypeScript support. You can use it the same way:
 
 ```sh


### PR DESCRIPTION
Fixes #663

Adds a warning in the docs that the test runner features are only available in Node.js 21 and above.