### PR TITLE
fix: generate sourcesContent when Node.js debugger is enabled

### DIFF
--- a/src/utils/transform/get-esbuild-options.ts
+++ b/src/utils/transform/get-esbuild-options.ts
@@ -10,12 +10,11 @@ export const baseConfig = Object.freeze({
 	loader: 'default',
 });
 
-const isNodeDebuggerEnabled = process.execArgv.some((flag) => {
+// match Node.js debugger flags
+// https://nodejs.org/api/cli.html#--inspecthostport
+const NODE_DEBUGGER_FLAG_REGEX = /^--inspect(?:-brk|-port|-publish-uid|-wait)?(?:=|$)/;
 
-	// match Node.js debugger flags
-	// https://nodejs.org/api/cli.html#--inspecthostport
-	return /--inspect(-brk|-port|-publish-uid|-wait)?/.test(flag)
-})
+const isNodeDebuggerEnabled = process.execArgv.some(flag => NODE_DEBUGGER_FLAG_REGEX.test(flag));
 
 export const cacheConfig = {
 	...baseConfig,

--- a/src/utils/transform/get-esbuild-options.ts
+++ b/src/utils/transform/get-esbuild-options.ts
@@ -10,6 +10,13 @@ export const baseConfig = Object.freeze({
 	loader: 'default',
 });
 
+const isNodeDebuggerEnabled = process.execArgv.some((flag) => {
+
+	// match Node.js debugger flags
+	// https://nodejs.org/api/cli.html#--inspecthostport
+	return /--inspect(-brk|-port|-publish-uid|-wait)?/.test(flag)
+})
+
 export const cacheConfig = {
 	...baseConfig,
 
@@ -17,11 +24,11 @@ export const cacheConfig = {
 
 	/**
 	 * Improve performance by only generating sourcesContent
-	 * when V8 coverage is enabled
+	 * when V8 coverage is enabled or Node.js debugger is enabled
 	 *
 	 * https://esbuild.github.io/api/#sources-content
 	 */
-	sourcesContent: Boolean(process.env.NODE_V8_COVERAGE),
+	sourcesContent: Boolean(process.env.NODE_V8_COVERAGE) || isNodeDebuggerEnabled,
 
 	/**
 	 * Smaller output for cache and marginal performance improvement:


### PR DESCRIPTION
This PR attempts to fix the issue described here: #661 

If make changes to `tsx/src/run.ts`, the `--inspect` flag will be confused with the flag of the custom program.

```sh
// run command
./dist/cli.mjs --inspect temp/test.ts --inspect-xxx

// tsx/src/run.ts
// `console.log(argv)`
[ '--inspect', 'temp/test.ts', '--inspect-xxx' ]
```

But in `src/utils/transform/get-esbuild-options.ts`, `process.execArgv` doesn't have this problem

```sh
// run command
./dist/cli.mjs --inspect temp/test.ts --inspect-xxx

// src/utils/transform/get-esbuild-options.ts
// `console.log(process.execArgv)`
[
  '--require',
  '/home/debian/tsx/dist/preflight.cjs',
  '--import',
  'file:///home/debian/tsx/dist/loader.mjs',
  '--inspect'
]
```
