### PR TITLE
feat(esm): support custom conditions

### DIFF
--- a/src/esm/hook/resolve.ts
+++ b/src/esm/hook/resolve.ts
@@ -8,7 +8,7 @@ import type { PackageJson } from 'type-fest';
 import { readJsonFile } from '../../utils/read-json-file.js';
 import { mapTsExtensions } from '../../utils/map-ts-extensions.js';
 import type { NodeError } from '../../types.js';
-import { tsconfigPathsMatcher, allowJs } from '../../utils/tsconfig.js';
+import { tsconfigPathsMatcher, allowJs, customConditions } from '../../utils/tsconfig.js';
 import {
 	requestAcceptsQuery,
 	fileUrlPrefix,
@@ -238,6 +238,13 @@ export const resolve: ResolveHook = async (
 ) => {
 	if (!data.active || specifier.startsWith('node:')) {
 		return nextResolve(specifier, context);
+	}
+
+	if (customConditions?.length) {
+		context.conditions = [
+			...(context.conditions ?? []),
+			...customConditions,
+		];
 	}
 
 	let requestNamespace = getNamespace(specifier) ?? (

--- a/src/utils/tsconfig.ts
+++ b/src/utils/tsconfig.ts
@@ -17,6 +17,9 @@ export let tsconfigPathsMatcher: undefined | ReturnType<typeof createPathsMatche
 // eslint-disable-next-line import-x/no-mutable-exports
 export let allowJs = false;
 
+// eslint-disable-next-line import-x/no-mutable-exports
+export let customConditions: string[] | undefined;
+
 export const loadTsconfig = (
 	configPath?: string,
 ) => {
@@ -52,4 +55,5 @@ export const loadTsconfig = (
 	fileMatcher = createFilesMatcher(tsconfig);
 	tsconfigPathsMatcher = createPathsMatcher(tsconfig);
 	allowJs = tsconfig?.config.compilerOptions?.allowJs ?? false;
+	customConditions = tsconfig?.config.compilerOptions?.customConditions;
 };


### PR DESCRIPTION
Add support for [customConditions](https://www.typescriptlang.org/tsconfig/#customConditions) in ESM.

For example, if a tsconfig contains this:

```json
{
	"compilerOptions": {
		"customConditions": ["source"],
	}
}
```

passing the condition as an arg to the CLI would not be needed anymore:

```diff
- tsx --conditions source src
+ tsx src
```

But this is only for ESM as explained here: https://github.com/privatenumber/tsx/issues/574#issuecomment-2156442343

Related to #574 