### PR TITLE
docs: update links to `npx`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ Before you can start using _tsx_, ensure that you have [Node.js installed](https
 
 ## Quickstart
 
-`tsx` can be executed with [npx](https://docs.npmjs.com/cli/commands/npx/) — a tool to run npm packages without installing them.
+`tsx` can be executed with [npx](https://docs.npmjs.com/cli/commands/npx/)—a tool to run npm packages without installing them.
 
 In your command-line, simply pass in a TypeScript file you'd like to run. It's that simple!
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ Before you can start using _tsx_, ensure that you have [Node.js installed](https
 
 ## Quickstart
 
-`tsx` can be executed with [npx](https://docs.npmjs.com/cli/v8/commands/npx)—a tool to run npm packages without installing them.
+`tsx` can be executed with [npx](https://docs.npmjs.com/cli/commands/npx/) — a tool to run npm packages without installing them.
 
 In your command-line, simply pass in a TypeScript file you'd like to run. It's that simple!
 
@@ -67,7 +67,7 @@ In the `scripts` object, you can reference `tsx` directly without `npx`:
 
 ## Global installation
 
-If you want to use `tsx` anywhere on your computer (without [`npx`](https://docs.npmjs.com/cli/v8/commands/npx)), install it globally:
+If you want to use `tsx` anywhere on your computer (without [`npx`](https://docs.npmjs.com/cli/commands/npx/)), install it globally:
 
 ::: code-group
 ```sh [npm]


### PR DESCRIPTION
This PR updates links to `npx` on page https://tsx.is/getting-started

Actual version of `npx` page is `https://docs.npmjs.com/cli/v10/commands/npx/`, but variant without version number (`https://docs.npmjs.com/cli/commands/npx/`) is also supported, this URL redirects to current version.

So I think using the `https://docs.npmjs.com/cli/commands/npx/` is the best choice.
