### PR TITLE
docs(faq, support sidebar): remove outdated links/references to sponsor-only Discussions page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -154,10 +154,6 @@ export default defineConfig({
 							link: '/learn',
 						},
 						{
-							text: 'Help center (Sponsors only)',
-							link: 'https://github.com/pvtnbr/tsx/discussions',
-						},
-						{
 							text: 'Become a Sponsor',
 							link: 'https://github.com/sponsors/privatenumber/sponsorships?tier_id=416984',
 						},

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -253,12 +253,6 @@ Here are some questions to help guide your decision:
 
 Ultimately, it's a decision you'll need to make based on your specific production requirements and comfort level with potential risks.
 
----
-
-# Ask a question
-
-_tsx_ offers support via [Discussions](https://github.com/pvtnbr/tsx/discussions) for [sponsors](https://github.com/sponsors/privatenumber/sponsorships?tier_id=416984). If you're a sponsor, feel free to ask more questions there!
-
 <style scoped>
 .bug-report {
 	@apply


### PR DESCRIPTION
~~It looks like the https://github.com/pvtnbr/tsx/discussions page no longer exists- as a sponsor I'm not able to see it (404 response). Likewise for https://github.com/privatenumber/tsx/discussions. 

Does it make sense to remove these, or is there somewhere else they should point?~~

My mistake! looks like it requires an org invite.