### PR TITLE
chore: enable npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write # to enable use of OIDC for npm provenance
 
 jobs:
   release:

--- a/package.json
+++ b/package.json
@@ -119,5 +119,8 @@
 			"node-pty",
 			"esbuild"
 		]
+	},
+	"publishConfig": {
+		"provenance": true
 	}
 }


### PR DESCRIPTION
Since this project uses `semantic-release` to publish directly from GitHub Actions, this should be a straightforward change to start [publishing the npm package with provenance](https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/), which is a nice little benefit.