### PR TITLE
fix: ignore native typescript formats

### DIFF
--- a/src/esm/hook/resolve.ts
+++ b/src/esm/hook/resolve.ts
@@ -336,6 +336,8 @@ let resolve: ResolveHook = async (
 	// For TypeScript extensions that Node can't detect the format of
 	if (
 		!resolved.format
+		|| resolved.format === 'commonjs-typescript'
+		|| resolved.format === 'module-typescript'
 		// Filter out data: (sourcemaps)
 		&& resolved.url.startsWith(fileUrlPrefix)
 	) {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/59364
This patch fixes compatibility with Node v24 and v22 type stripping.