### PR TITLE
fix: properly hide relaySignal from process.listeners()

### DIFF
--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -181,7 +181,7 @@ export default testSuite(({ describe }, node: NodeApis) => {
 				'hidden-signals-handler.js': `
 				console.log('process.listeners().length = ' + process.listeners('SIGINT').length);
 				console.log('process.listenerCount() = ' + process.listenerCount('SIGINT'));
-				`
+				`,
 			});
 			onFinish(async () => await fixture.rm());
 

--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -178,6 +178,10 @@ export default testSuite(({ describe }, node: NodeApis) => {
 				});
 				setTimeout(() => {}, 1e5);
 				`,
+				'hidden-signals-handler.js': `
+				console.log('process.listeners().length = ' + process.listeners('SIGINT').length);
+				console.log('process.listenerCount() = ' + process.listenerCount('SIGINT'));
+				`
 			});
 			onFinish(async () => await fixture.rm());
 
@@ -304,6 +308,17 @@ export default testSuite(({ describe }, node: NodeApis) => {
 			}, {
 				timeout: 10_000,
 				retry: 3,
+			});
+
+			test('Relay signal handlers are properly hidden', async () => {
+				const tsxProcess = tsx([
+					fixture.getPath('hidden-signals-handler.js'),
+				]);
+
+				const result = await tsxProcess;
+
+				expect(result.stdout).toBe('process.listeners().length = 0\nprocess.listenerCount() = 0');
+				expect(result.exitCode).toBe(0);
 			});
 
 			describe('Ctrl + C', ({ test }) => {


### PR DESCRIPTION
Closes https://github.com/privatenumber/tsx/issues/742

A past commit (https://github.com/privatenumber/tsx/commit/a88289d70dacdec8d6ed99c27d0d35dfb22975fb) broke [the comparison](https://github.com/privatenumber/tsx/blob/20b91c44bbb00006f182fee3b0bcfc55aaec6e44/src/preflight.cts#L44) in the monkey-patched `process.listeners()`.

The passed `handler` is not directly attached as a listener anymore, but only called in an anonymous listener. So the reference comparison is broken.

To fix this, store the listeners in a map, then compare against the stored listeners.