### PR TITLE
feat: add flag to disable tsx watch from reading from process.stdin

### DIFF
--- a/docs/watch-mode.md
+++ b/docs/watch-mode.md
@@ -51,3 +51,4 @@ tsx watch --exclude "./data/**/*" ./file.ts
 
 - Press <kbd>Return</kbd> to manually rerun the script.
 - Use `--clear-screen=false` to prevent the screen from clearing on rerun.
+- Use `--reload-on-keypress=false` to disable reloading on keypress. If your child process uses stdin raw mode, be sure to disable this.

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -45,6 +45,11 @@ const flags = {
 		type: [String],
 		description: 'Paths & globs to exclude from being watched',
 	},
+	reloadOnKeypress: {
+		type: Boolean,
+		description: 'Reload on keypress (press Return key to manually rerun). Disable if your process uses stdin raw mode.',
+		default: true,
+	},
 } as const;
 
 export const watchCommand = command({
@@ -232,5 +237,7 @@ export const watchCommand = command({
 	).on('all', reRun);
 
 	// On "Return" key
-	process.stdin.on('data', () => reRun('Return key'));
+	if (argv.flags.reloadOnKeypress && process.stdin.isTTY) {
+		process.stdin.on('data', () => reRun('Return key'));
+	}
 });


### PR DESCRIPTION
### Acknowledgements

- [x] I read the documentation and searched existing issues to avoid duplicates
- [x] I understand this is a **bug tracker** and anything other than a proven bug will be closed
- [x] I understand this is a free project and relies on community contributions
- [x] I read and understood the [Contribution guide](https://github.com/privatenumber/tsx/blob/master/CONTRIBUTING.md)


### bug

There are som limitations to an inherited stdin:
- When the child process reads from stdin, the parent process also reading from stdin causes conflicts (race to read, only one reads).
- When the child process sets the stdin mode to "raw mode", every key press seen by the parent (see race above) causes the parent to restart the child.

### proposal

Add an option to disable the stdin reads for the reload check

The default was selected so as to not introduce a breaking change.
The flag name `--reload-on-keypress`(a bit inexact), was chosen to leave room for the reload triggering key to change via a future flag.

### Relevant issues:
- essentially the same PR https://github.com/privatenumber/tsx/pull/220/files
- help wanted: alternatives for triggering reload https://github.com/privatenumber/tsx/issues/215#issuecomment-1794274016
- watch breaks stdin for child https://github.com/privatenumber/tsx/issues/163
- `process.stdin.isRaw` does not necessarily reflect the actual mode https://github.com/nodejs/node/issues/47938

### other notes
the child sharing a stdin adds some complications, as the child may expect a certain mode or change the mode. its possible to instead do set stdin to `'pipe'` in the spawn config, set the parent in raw mode, and pipe input into the child. another alternative may be to give the child a pseudoterminal https://github.com/microsoft/node-pty
i haven't explored these options in depth