### PR TITLE
fix: stop breaking data URLs with namespace queries

### DIFF
--- a/src/esm/hook/resolve.ts
+++ b/src/esm/hook/resolve.ts
@@ -355,9 +355,11 @@ let resolve: ResolveHook = async (
 	}
 
 	// Inherit namespace
+	// Skip data URLs as they cannot properly handle query parameters
 	if (
 		requestNamespace
 		&& !resolved.url.includes(namespaceQuery)
+		&& !resolved.url.startsWith('data:')
 	) {
 		resolved.url += (resolved.url.includes('?') ? '&' : '?') + namespaceQuery + requestNamespace;
 	}


### PR DESCRIPTION
Data URLs can't handle query parameters, but tsx was adding `?tsx-namespace` to them anyway which caused Invalid URL errors in Node. Now we skip the namespace parameter entirely when the URL starts with `data:`.

Fixes #750