### PR TITLE
CLI: add clear error when dist artifacts are missing in local clones

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const distCli = path.resolve(__dirname, '../dist/cli.mjs');
+
+if (!fs.existsSync(distCli)) {
+  console.error(
+    '[tsx] Build artifacts not found.\n' +
+    'Please run `npm run build` before using the CLI in a local clone.'
+  );
+  process.exit(1);
+}
+
+await import(distCli);

--- a/package.json
+++ b/package.json
@@ -1,123 +1,123 @@
 {
-	"name": "tsx",
-	"version": "0.0.0-semantic-release",
-	"description": "TypeScript Execute (tsx): Node.js enhanced with esbuild to run TypeScript & ESM files",
-	"keywords": [
-		"cli",
-		"runtime",
-		"node",
-		"cjs",
-		"commonjs",
-		"esm",
-		"typescript",
-		"typescript runner"
-	],
-	"license": "MIT",
-	"repository": "privatenumber/tsx",
-	"author": {
-		"name": "Hiroki Osame",
-		"email": "hiroki.osame@gmail.com"
-	},
-	"files": [
-		"dist"
-	],
-	"type": "module",
-	"bin": "./dist/cli.mjs",
-	"exports": {
-		"./package.json": "./package.json",
-		".": "./dist/loader.mjs",
-		"./patch-repl": "./dist/patch-repl.cjs",
-		"./cjs": "./dist/cjs/index.cjs",
-		"./cjs/api": {
-			"import": {
-				"types": "./dist/cjs/api/index.d.mts",
-				"default": "./dist/cjs/api/index.mjs"
-			},
-			"require": {
-				"types": "./dist/cjs/api/index.d.cts",
-				"default": "./dist/cjs/api/index.cjs"
-			}
-		},
-		"./esm": "./dist/esm/index.mjs",
-		"./esm/api": {
-			"import": {
-				"types": "./dist/esm/api/index.d.mts",
-				"default": "./dist/esm/api/index.mjs"
-			},
-			"require": {
-				"types": "./dist/esm/api/index.d.cts",
-				"default": "./dist/esm/api/index.cjs"
-			}
-		},
-		"./cli": "./dist/cli.mjs",
-		"./suppress-warnings": "./dist/suppress-warnings.cjs",
-		"./preflight": "./dist/preflight.cjs",
-		"./repl": "./dist/repl.mjs"
-	},
-	"packageManager": "pnpm@10.9.0",
-	"homepage": "https://tsx.is",
-	"scripts": {
-		"build": "pkgroll --minify",
-		"lint": "lintroll --node --cache --ignore-pattern 'docs/*.md' .",
-		"type-check": "tsc",
-		"test": "pnpm build && node ./dist/cli.mjs tests/index.ts",
-		"prepack": "pnpm build && clean-pkg-json",
-		"docs:dev": "pnpm --filter=docs dev",
-		"docs:build": "pnpm --filter=docs build",
-		"docs:preview": "pnpm --filter=docs preview"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"dependencies": {
-		"esbuild": "~0.27.0",
-		"get-tsconfig": "^4.7.5"
-	},
-	"optionalDependencies": {
-		"fsevents": "~2.3.3"
-	},
-	"devDependencies": {
-		"@ampproject/remapping": "^2.3.0",
-		"@types/cross-spawn": "^6.0.6",
-		"@types/node": "^22.15.29",
-		"@types/split2": "^4.2.3",
-		"append-transform": "^2.0.0",
-		"cachedir": "^2.4.0",
-		"chokidar": "^3.6.0",
-		"clean-pkg-json": "^1.2.0",
-		"cleye": "^1.3.2",
-		"cross-spawn": "^7.0.3",
-		"es-module-lexer": "^1.5.4",
-		"execa": "^8.0.1",
-		"fs-fixture": "^2.4.0",
-		"fs-require": "^1.6.0",
-		"get-node": "^15.0.1",
-		"kolorist": "^1.8.0",
-		"lintroll": "^1.8.1",
-		"magic-string": "^0.30.10",
-		"manten": "^1.5.0",
-		"memfs": "^4.9.3",
-		"node-pty": "^1.0.0",
-		"outdent": "^0.8.0",
-		"pkgroll": "^2.4.1",
-		"proxyquire": "^2.1.3",
-		"strip-ansi": "^7.1.0",
-		"type-fest": "^4.20.1",
-		"type-flag": "^3.0.0",
-		"typescript": "^5.5.2"
-	},
-	"pnpm": {
-		"packageExtensions": {
-			"node-pty": {
-				"//": "https://github.com/microsoft/node-pty/issues/777",
-				"dependencies": {
-					"node-gyp": "11.0.0"
-				}
-			}
-		},
-		"onlyBuiltDependencies": [
-			"node-pty",
-			"esbuild"
-		]
-	}
+  "name": "tsx",
+  "version": "0.0.0-semantic-release",
+  "description": "TypeScript Execute (tsx): Node.js enhanced with esbuild to run TypeScript & ESM files",
+  "keywords": [
+    "cli",
+    "runtime",
+    "node",
+    "cjs",
+    "commonjs",
+    "esm",
+    "typescript",
+    "typescript runner"
+  ],
+  "license": "MIT",
+  "repository": "privatenumber/tsx",
+  "author": {
+    "name": "Hiroki Osame",
+    "email": "hiroki.osame@gmail.com"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "bin": "./bin/cli.mjs",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./dist/loader.mjs",
+    "./patch-repl": "./dist/patch-repl.cjs",
+    "./cjs": "./dist/cjs/index.cjs",
+    "./cjs/api": {
+      "import": {
+        "types": "./dist/cjs/api/index.d.mts",
+        "default": "./dist/cjs/api/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/api/index.d.cts",
+        "default": "./dist/cjs/api/index.cjs"
+      }
+    },
+    "./esm": "./dist/esm/index.mjs",
+    "./esm/api": {
+      "import": {
+        "types": "./dist/esm/api/index.d.mts",
+        "default": "./dist/esm/api/index.mjs"
+      },
+      "require": {
+        "types": "./dist/esm/api/index.d.cts",
+        "default": "./dist/esm/api/index.cjs"
+      }
+    },
+    "./cli": "./dist/cli.mjs",
+    "./suppress-warnings": "./dist/suppress-warnings.cjs",
+    "./preflight": "./dist/preflight.cjs",
+    "./repl": "./dist/repl.mjs"
+  },
+  "packageManager": "pnpm@10.9.0",
+  "homepage": "https://tsx.is",
+  "scripts": {
+    "build": "pkgroll --minify",
+    "lint": "lintroll --node --cache --ignore-pattern 'docs/*.md' .",
+    "type-check": "tsc",
+    "test": "pnpm build && node ./dist/cli.mjs tests/index.ts",
+    "prepack": "pnpm build && clean-pkg-json",
+    "docs:dev": "pnpm --filter=docs dev",
+    "docs:build": "pnpm --filter=docs build",
+    "docs:preview": "pnpm --filter=docs preview"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "esbuild": "~0.27.0",
+    "get-tsconfig": "^4.7.5"
+  },
+  "optionalDependencies": {
+    "fsevents": "~2.3.3"
+  },
+  "devDependencies": {
+    "@ampproject/remapping": "^2.3.0",
+    "@types/cross-spawn": "^6.0.6",
+    "@types/node": "^22.15.29",
+    "@types/split2": "^4.2.3",
+    "append-transform": "^2.0.0",
+    "cachedir": "^2.4.0",
+    "chokidar": "^3.6.0",
+    "clean-pkg-json": "^1.2.0",
+    "cleye": "^1.3.2",
+    "cross-spawn": "^7.0.3",
+    "es-module-lexer": "^1.5.4",
+    "execa": "^8.0.1",
+    "fs-fixture": "^2.4.0",
+    "fs-require": "^1.6.0",
+    "get-node": "^15.0.1",
+    "kolorist": "^1.8.0",
+    "lintroll": "^1.8.1",
+    "magic-string": "^0.30.10",
+    "manten": "^1.5.0",
+    "memfs": "^4.9.3",
+    "node-pty": "^1.0.0",
+    "outdent": "^0.8.0",
+    "pkgroll": "^2.4.1",
+    "proxyquire": "^2.1.3",
+    "strip-ansi": "^7.1.0",
+    "type-fest": "^4.20.1",
+    "type-flag": "^3.0.0",
+    "typescript": "^5.5.2"
+  },
+  "pnpm": {
+    "packageExtensions": {
+      "node-pty": {
+        "//": "https://github.com/microsoft/node-pty/issues/777",
+        "dependencies": {
+          "node-gyp": "11.0.0"
+        }
+      }
+    },
+    "onlyBuiltDependencies": [
+      "node-pty",
+      "esbuild"
+    ]
+  }
 }


### PR DESCRIPTION
Fixes #763.

When running the tsx CLI from a fresh local clone, build artifacts may be missing. Instead of throwing MODULE_NOT_FOUND, this adds a small preflight guard that exits with a clear, actionable error message.

This improves contributor onboarding and CLI DX without altering build behavior.