### PR TITLE
fix(esm/hook/resolve): tsconfig when in node_modules

### DIFF
--- a/src/esm/hook/resolve.ts
+++ b/src/esm/hook/resolve.ts
@@ -249,14 +249,12 @@ const resolveTsPaths: ResolveHook = async (
 
 		requestAcceptsQuery: requestAcceptsQuery(specifier),
 		tsconfigPathsMatcher,
-		fromNodeModules: context.parentURL?.includes('/node_modules/'),
 	});
 	if (
 		// Bare specifier
 		!requestAcceptsQuery(specifier)
 		// TS path alias
 		&& tsconfigPathsMatcher
-		&& !context.parentURL?.includes('/node_modules/')
 	) {
 		const possiblePaths = tsconfigPathsMatcher(specifier);
 		log(3, 'resolveTsPaths', {

--- a/tests/specs/tsconfig.ts
+++ b/tests/specs/tsconfig.ts
@@ -84,31 +84,6 @@ export default testSuite(async ({ describe }, { tsx }: NodeApis) => {
 					'import-typescript-child.ts': `
 					console.log('imported');
 					`,
-
-					'node_modules/tsconfig-should-not-apply': {
-						'package.json': createPackageJson({
-							exports: {
-								import: './index.mjs',
-								default: './index.cjs',
-							},
-						}),
-						'index.mjs': `
-						import { expectErrors } from 'expect-errors';
-						expectErrors(
-							[() => import ('prefix/file'), "Cannot find package 'prefix'"],
-							[() => import ('paths-exact-match'), "Cannot find package 'paths-exact-match'"],
-							[() => import ('file'), "Cannot find package 'file'"],
-						);
-						`,
-						'index.cjs': `
-						const { expectErrors } = require('expect-errors');
-						expectErrors(
-							[() => require('prefix/file'), "Cannot find module"],
-							[() => require('paths-exact-match'), "Cannot find module"],
-							[() => require('file'), "Cannot find module"],
-						);
-						`,
-					},
 				});
 				onFinish(async () => await fixture.rm());
 


### PR DESCRIPTION
(It seems that some tests was already failing)

This removes the check if any of parent directory is `node_modules`,
allowing [a lib to be built manually, in cases it is installed directly
from a Git repo](https://browse.library.kiwix.org/content/stackoverflow.com_en_all_2023-11/questions/48287776/automatically-build-npm-module-on-install-from-github)

Example reproducing the issue https://github.com/thisago/tsx-issue-importing-from-node-modules

It seems to be [intended because](https://github.com/thisago/tsx/commit/e46366d2308afdf2dd197165854ff48f94a4b753) [it had tests](https://github.com/privatenumber/tsx/pull/360), but this behavior makes impossible to run a file when it's inside a `node_modules`.