### PR TITLE
feat: Make kill-timeout configurable

### DIFF
--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -32,6 +32,11 @@ const flags = {
 		description: 'Clearing the screen on rerun',
 		default: true,
 	},
+	killTimeout: {
+		type: Number,
+		description: 'Milliseconds until process is forcibly killed'
+		default: 5000
+	},
 	// Deprecated
 	ignore: {
 		type: [String],
@@ -68,6 +73,7 @@ export const watchCommand = command({
 		noCache: argv.flags.noCache,
 		tsconfigPath: argv.flags.tsconfig,
 		clearScreen: argv.flags.clearScreen,
+		killTimeout: argv.flags.killTimeout,
 		include: argv.flags.include,
 		exclude: [
 			...argv.flags.ignore,
@@ -116,7 +122,6 @@ export const watchCommand = command({
 	const killProcess = async (
 		childProcess: ChildProcess,
 		signal: NodeJS.Signals = 'SIGTERM',
-		forceKillOnTimeout = 5000,
 	) => {
 		let exited = false;
 		const waitForExit = new Promise<number | null>((resolve) => {
@@ -132,10 +137,10 @@ export const watchCommand = command({
 
 		setTimeout(() => {
 			if (!exited) {
-				log(yellow(`Process didn't exit in ${Math.floor(forceKillOnTimeout / 1000)}s. Force killing...`));
+				log(yellow(`Process didn't exit in ${Math.floor(options.killTimeout / 1000)}s. Force killing...`));
 				childProcess.kill('SIGKILL');
 			}
-		}, forceKillOnTimeout);
+		}, options.killTimeout);
 
 		return await waitForExit;
 	};

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -34,7 +34,7 @@ const flags = {
 	},
 	killTimeout: {
 		type: Number,
-		description: 'Milliseconds until process is forcibly killed'
+		description: 'Milliseconds until process is forcibly killed',
 		default: 5000
 	},
 	// Deprecated


### PR DESCRIPTION
### Why I thought about this
My application registers custom handlers with calls like `process.on('SIGINT')`. In there, I am waiting to gracefully shutdown another process. This takes some time, sometimes more than 5 seconds. The idea is to have this configurable so that no `SIGKILL` is sent that breaks saving in the childprocess.

### Description
This PR implements a new flag `--kill-timeout <number>` for the `watch` subcommand. The number is used in the timeout to change and possibly extend the grace period until the process is killed after sending the SIGINT.

I am happy to implement any feedback provided.