### PR TITLE
chore: fix typos in a doc and a comment

### DIFF
--- a/docs/dev-api/entry-point.md
+++ b/docs/dev-api/entry-point.md
@@ -9,7 +9,7 @@ await import('./file.ts')
 ```
 <!-- TODO: does this work in CJS mode? -->
 
-Note, because of the order of static import evaluatation in ESM, the enhancement only works on [dynamic imports after registeration](https://nodejs.org/docs/latest-v22.x/api/module.html#:~:text=dynamic%20import()%20must%20be%20used%20for%20any%20code%20that%20should%20be%20run%20after%20the%20hooks%20are%20registered).
+Note, because of the order of static import evaluation in ESM, the enhancement only works on [dynamic imports after registeration](https://nodejs.org/docs/latest-v22.x/api/module.html#:~:text=dynamic%20import()%20must%20be%20used%20for%20any%20code%20that%20should%20be%20run%20after%20the%20hooks%20are%20registered).
 
 ::: danger
 Enhancing Node.js by loading _tsx_ from within your source code at run-time can be unexpected for collaborators who aren’t aware of it.

--- a/docs/dev-api/entry-point.md
+++ b/docs/dev-api/entry-point.md
@@ -9,7 +9,7 @@ await import('./file.ts')
 ```
 <!-- TODO: does this work in CJS mode? -->
 
-Note, because of the order of static import evaluation in ESM, the enhancement only works on [dynamic imports after registeration](https://nodejs.org/docs/latest-v22.x/api/module.html#:~:text=dynamic%20import()%20must%20be%20used%20for%20any%20code%20that%20should%20be%20run%20after%20the%20hooks%20are%20registered).
+Note, because of the order of static import evaluation in ESM, the enhancement only works on [dynamic imports after registration](https://nodejs.org/docs/latest-v22.x/api/module.html#:~:text=dynamic%20import()%20must%20be%20used%20for%20any%20code%20that%20should%20be%20run%20after%20the%20hooks%20are%20registered).
 
 ::: danger
 Enhancing Node.js by loading _tsx_ from within your source code at run-time can be unexpected for collaborators who aren’t aware of it.

--- a/src/cjs/api/module-extensions.ts
+++ b/src/cjs/api/module-extensions.ts
@@ -178,7 +178,7 @@ export const createExtensions = (
 	for (const extension of implicitlyResolvableExtensions) {
 		safeSet(extensions, extension, transformer, {
 			/**
-			 * Registeration needs to be enumerable for some 3rd party libraries
+			 * Registration needs to be enumerable for some 3rd party libraries
 			 * https://github.com/gulpjs/rechoir/blob/v0.8.0/index.js#L21 (used by Webpack CLI)
 			 *
 			 * If the extension already exists, inherit its enumerable property


### PR DESCRIPTION
> [!NOTE]
> This PR only includes documentation and comment updates and has no impact on runtime behavior.

# Summary

I just fixed typos like the followings.

- `registeration` to `registration`
- `evaluatation` to `evaluation`