### PR TITLE
store IPC messages before connection

### DIFF
--- a/src/utils/ipc/client.ts
+++ b/src/utils/ipc/client.ts
@@ -35,8 +35,10 @@ const connectToServer = () => new Promise<SendToParent | void>((resolve) => {
 	socket.unref();
 });
 
+// before connection, store messages locally
+const queue = [];
 export const parent: Parent = {
-	send: undefined,
+	send: x => queue.push(x),
 };
 
 export const connectingToServer = connectToServer();
@@ -44,6 +46,10 @@ export const connectingToServer = connectToServer();
 connectingToServer.then(
 	(send) => {
 		parent.send = send;
+		
+		// process the queue
+		queue.forEach(x => send(x));
+		queue.length = 0;
 	},
 	() => {},
 );

--- a/src/utils/ipc/client.ts
+++ b/src/utils/ipc/client.ts
@@ -48,8 +48,10 @@ connectingToServer.then(
 		parent.send = send;
 		
 		// process the queue
-		queue.forEach(x => send(x));
-		queue.length = 0;
+        if (!!send) {
+		  queue.forEach(x => send(x));
+		  queue.length = 0;
+		}
 	},
 	() => {},
 );


### PR DESCRIPTION
In the new node v24, I found out the IPC messages are lost as the IPC connection is yet to be setup/connected.
This is maybe due to a different import/load order strategy in node.

Anyway, a simple fix was to just cache the messages and replay them when the connection is established.

This fixes the "watch doesn't restart on changes".
Solves #767