### PR TITLE
fix: suppress importAttributes deprecation warning

### DIFF
--- a/src/suppress-warnings.cts
+++ b/src/suppress-warnings.cts
@@ -10,6 +10,9 @@ const ignoreWarnings = new Set([
 
 	// For JSON modules via https://github.com/nodejs/node/pull/46901
 	'Import assertions are not a stable feature of the JavaScript language. Avoid relying on their current behavior and syntax as those might change in a future version of Node.js.',
+
+	// importAssertions deprecated in favor of importAttributes (Node v22.20.0+)
+	'Use `importAttributes` instead of `importAssertions`',
 ]);
 
 const { emit } = process;


### PR DESCRIPTION
## Summary

Suppresses the `ExperimentalWarning: Use \`importAttributes\` instead of \`importAssertions\`` warning that appears starting with Node.js v22.20.0.

## Problem

After migrating to Node.js 22.20.0+, users see this warning when starting their apps:
```
(node:1) ExperimentalWarning: Use \`importAttributes\` instead of \`importAssertions\`
```

The warning is triggered because tsx uses the deprecated `importAssertions` property for backward compatibility.

## Solution

Added the warning message to the existing `ignoreWarnings` Set in `suppress-warnings.cts`, following the same pattern used for other suppressed warnings.

Fixes #775