### PR TITLE
feat: add support for import.meta.dirname and import.meta.filename

### DIFF
--- a/src/utils/transform/index.ts
+++ b/src/utils/transform/index.ts
@@ -1,4 +1,5 @@
 import { pathToFileURL, fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import {
 	transform as esbuildTransform,
 	transformSync as esbuildTransformSync,
@@ -61,6 +62,8 @@ export const transformSync = (
 		)
 	) {
 		define['import.meta.url'] = JSON.stringify(url);
+		define['import.meta.dirname'] = JSON.stringify(dirname(filePath));
+		define['import.meta.filename'] = JSON.stringify(filePath);
 	}
 
 	const esbuildOptions = {


### PR DESCRIPTION
## Fixes #781

Adds support for Node.js 20.11+ `import.meta.dirname` and `import.meta.filename` properties.

### Problem
- .js files transformed to CJS had `undefined` for these properties
- Caused TypeError crashes when code tried to use them  
- .ts and .mjs files already worked (different code path)

### Solution  
Follow same pattern as `import.meta.url` using esbuild `define`.

### Testing
```bash
# Before: tsx test.js → undefined, undefined
# After: tsx test.js → /path/to/dir, /path/to/dir/test.js
```

Reference: https://github.com/unjs/jiti/pull/308