### PR TITLE
fix: queue IPC messages sent before socket connection is established

### DIFF
--- a/src/utils/ipc/client.ts
+++ b/src/utils/ipc/client.ts
@@ -35,8 +35,10 @@ const connectToServer = () => new Promise<SendToParent | void>((resolve) => {
 	socket.unref();
 });
 
+// Buffer messages sent before the connection is established
+const queue: Record<string, unknown>[] = [];
 export const parent: Parent = {
-	send: undefined,
+	send: x => queue.push(x),
 };
 
 export const connectingToServer = connectToServer();
@@ -44,6 +46,10 @@ export const connectingToServer = connectToServer();
 connectingToServer.then(
 	(send) => {
 		parent.send = send;
+		if (send) {
+			queue.forEach(x => send(x));
+			queue.length = 0;
+		}
 	},
 	() => {},
 );

--- a/tests/specs/watch.ts
+++ b/tests/specs/watch.ts
@@ -74,6 +74,55 @@ export default testSuite(async ({ describe }, { tsx }: NodeApis) => {
 			}, 10_000);
 		}
 
+		test('tracks dependencies loaded before IPC connects', async ({ onTestFinish, onTestFail }) => {
+			const fixtureWatch = await createFixture({
+				'package.json': createPackageJson({ type: 'commonjs' }),
+				'index.js': `
+				import { value } from './value.js';
+				console.log(value);
+				`,
+				'value.js': 'export const value = \'hello world\';',
+			});
+			onTestFinish(async () => await fixtureWatch.rm());
+
+			const tsxProcess = tsx(
+				[
+					'watch',
+					'--clear-screen=false',
+					'index.js',
+				],
+				fixtureWatch.path,
+			);
+
+			onTestFail(async () => {
+				if (tsxProcess.exitCode === null) {
+					console.log('Force killing hanging process\n\n');
+					tsxProcess.kill('SIGKILL');
+					console.log({ tsxProcess: await tsxProcess });
+				}
+			});
+
+			// No artificial delay: verifies that dependencies reported via IPC before
+			// the socket connection is established are still queued and delivered
+			await processInteract(
+				tsxProcess.stdout!,
+				[
+					(data) => {
+						if (data.includes('hello world\n')) {
+							fixtureWatch.writeFile('value.js', 'export const value = \'goodbye world\';');
+							return true;
+						}
+					},
+					data => data.includes('[tsx] change in ./value.js Rerunning...\n'),
+					data => data.includes('goodbye world\n'),
+				],
+				9000,
+			);
+
+			tsxProcess.kill();
+			await tsxProcess;
+		}, 10_000);
+
 		test('suppresses warnings & clear screen', async () => {
 			const tsxProcess = tsx(
 				[


### PR DESCRIPTION
Implements the fix from #774 with an added regression test.

I noticed #774 has been open for a while and I can't push to someone else's PR, so I'm opening this one with the same fix plus a test to cover it.

## What's broken

On Node v24, CJS modules load fast enough that `parent.send()` is called (from the require hook) before the IPC socket connection to the watch server is established. Since `parent.send` was initialised to `undefined`, the `if (parent.send)` guard in the hook silently drops every dependency message — so the watcher never learns about imported files and watch mode never restarts on changes.

## Fix

Initialise `parent.send` to a queue function instead of `undefined`. Messages sent before the socket connects are buffered, then flushed once the connection resolves. If the connection fails (no watch server), the queue is discarded.

## Test

Added `tracks dependencies loaded before IPC connects` to `tests/specs/watch.ts`:
- Uses a `commonjs` package fixture (the package type where the race manifests on Node 24)
- Changes the imported dependency immediately after first output — no artificial delay
- **Fails on Node 24.14.1 without the fix** (times out waiting for restart)
- **Passes on Node 24.14.1 with the fix**
- Passes on Node 20 regardless (timing doesn't trigger the race there)

Closes #767