### PR TITLE
feat: migrate to module.registerHooks() natively for Node 26 compatibility

### DIFF
--- a/src/cjs/api/module-extensions.ts
+++ b/src/cjs/api/module-extensions.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import Module from 'node:module';
 import type { TransformOptions } from 'esbuild';
-import { isFileIncluded, type TsconfigResult } from 'get-tsconfig';
+import type { TsconfigResult } from 'get-tsconfig';
 import { transformSync } from '../../utils/transform/index.js';
 import { transformDynamicImport } from '../../utils/transform/transform-dynamic-import.js';
 import { isESM } from '../../utils/es-module-lexer.js';
@@ -146,6 +146,8 @@ export const createExtensions = (
 			// CommonJS file but uses ESM import/export
 			|| isESM(code)
 		) {
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			const { isFileIncluded } = require('get-tsconfig') as typeof import('get-tsconfig');
 			const transformed = transformSync(
 				code,
 				filePath,

--- a/src/cjs/api/module-resolve-filename/index.ts
+++ b/src/cjs/api/module-resolve-filename/index.ts
@@ -1,6 +1,6 @@
 import Module from 'node:module';
 import { fileURLToPath } from 'node:url';
-import { resolvePathAlias, type TsconfigResult } from 'get-tsconfig';
+import type { TsconfigResult } from 'get-tsconfig';
 import {
 	isFilePath,
 	fileUrlPrefix,
@@ -35,6 +35,8 @@ const resolveTsPaths = (
 		// Dependency paths should not be resolved using tsconfig.json
 		&& !parent?.filename?.includes(nodeModulesPath)
 	) {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const { resolvePathAlias } = require('get-tsconfig') as typeof import('get-tsconfig');
 		const possiblePaths = resolvePathAlias(tsconfig, request);
 		for (const possiblePath of possiblePaths) {
 			try {

--- a/src/esm/api/register.ts
+++ b/src/esm/api/register.ts
@@ -4,6 +4,9 @@ import type { Message } from '../types.js';
 import type { RequiredProperty } from '../../types.js';
 import { interopCjsExports } from '../../cjs/api/module-resolve-filename/interop-cjs-exports.js';
 import { createScopedImport, type ScopedImport } from './scoped-import.js';
+import { loadSync, resolveSync } from '../hook/index.js';
+import { data } from '../hook/initialize.js';
+import { loadTsconfig } from '../../utils/tsconfig.js';
 
 export type TsconfigOptions = false | string;
 
@@ -36,8 +39,8 @@ let cjsInteropApplied = false;
 export const register: Register = (
 	options,
 ) => {
-	if (!module.register) {
-		throw new Error(`This version of Node.js (${process.version}) does not support module.register(). Please upgrade to Node v18.19 or v20.6 and above.`);
+	if (!module.register && !module.registerHooks) {
+		throw new Error(`This version of Node.js (${process.version}) does not support module.register() or module.registerHooks(). Please upgrade to Node v18.19 or v20.6 and above.`);
 	}
 
 	if (!cjsInteropApplied) {
@@ -54,6 +57,50 @@ export const register: Register = (
 
 	const { sourceMapsEnabled } = process;
 	process.setSourceMapsEnabled(true);
+
+	if (module.registerHooks) {
+
+		// Initialize shared data (normally done by module.register's initialize hook)
+		data.namespace = options?.namespace;
+		if (options?.tsconfig !== false) {
+			data.parsedTsconfig = loadTsconfig(options?.tsconfig ?? process.env.TSX_TSCONFIG_PATH);
+		}
+
+		let onImportPort: import('node:worker_threads').MessagePort | undefined;
+		if (options?.onImport) {
+			const { port1, port2 } = new MessageChannel();
+			data.port = port2;
+			const { onImport } = options;
+			onImportPort = port1;
+			port1.on('message', (message: Message) => {
+				if (message.type === 'load') {
+					onImport(message.url);
+				}
+			});
+			port1.unref();
+		}
+
+		const hooks = module.registerHooks({
+			resolve: resolveSync as Parameters<typeof module.registerHooks>[0]['resolve'],
+			load: loadSync as Parameters<typeof module.registerHooks>[0]['load'],
+		});
+
+		const unregisterFn = async () => {
+			if (sourceMapsEnabled === false) {
+				process.setSourceMapsEnabled(false);
+			}
+			hooks.deregister();
+			data.port = undefined;
+			onImportPort?.close();
+		};
+
+		const unregister = unregisterFn as unknown as NamespacedUnregister;
+		if (options?.namespace) {
+			unregister.import = createScopedImport(options.namespace);
+			unregister.unregister = unregisterFn;
+		}
+		return unregister;
+	}
 
 	const { port1, port2 } = new MessageChannel();
 	module.register(

--- a/src/esm/hook/index.ts
+++ b/src/esm/hook/index.ts
@@ -1,3 +1,5 @@
 export { initialize, globalPreload } from './initialize.js';
 export { load } from './load.js';
 export { resolve } from './resolve.js';
+export { loadSync } from './load.js';
+export { resolveSync } from './resolve.js';

--- a/src/esm/hook/load.ts
+++ b/src/esm/hook/load.ts
@@ -1,9 +1,9 @@
 import { fileURLToPath } from 'node:url';
 import type { LoadHook } from 'node:module';
 import { readFile } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
 import type { TransformOptions } from 'esbuild';
-import { isFileIncluded } from 'get-tsconfig';
-import { transform, transformSync } from '../../utils/transform/index.js';
+import { transform, transformSync, transformEsmSync } from '../../utils/transform/index.js';
 import { transformDynamicImport } from '../../utils/transform/transform-dynamic-import.js';
 import { inlineSourceMap } from '../../source-map.js';
 import { isFeatureSupported, importAttributes, esmLoadReadFile } from '../../utils/node-features.js';
@@ -14,6 +14,8 @@ import { isESM } from '../../utils/es-module-lexer.js';
 import { logEsm as log, debugEnabled } from '../../utils/debug.js';
 import { getNamespace } from './utils.js';
 import { data } from './initialize.js';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const isFileIncluded: typeof import('get-tsconfig')['isFileIncluded'] = (...args) => (require('get-tsconfig') as typeof import('get-tsconfig')).isFileIncluded(...args);
 
 const importAttributesProperty = (
 	isFeatureSupported(importAttributes)
@@ -182,4 +184,116 @@ if (debugEnabled) {
 	};
 }
 
+
 export { load };
+
+export const loadSync = (
+	url: string,
+	context: any,
+	nextLoad: any,
+) => {
+	if (!data.active) {
+		return nextLoad(url, context);
+	}
+
+	const urlNamespace = getNamespace(url);
+	if (data.namespace && data.namespace !== urlNamespace) {
+		return nextLoad(url, context);
+	}
+
+	if (data.port) {
+		const parsedUrl = new URL(url);
+		parsedUrl.searchParams.delete('tsx-namespace');
+		data.port.postMessage({
+			type: 'load',
+			url: parsedUrl.toString(),
+		} satisfies Message);
+	}
+
+	if (parent.send) {
+		parent.send({
+			type: 'dependency',
+			path: url,
+		});
+	}
+
+	if (isJsonPattern.test(url)) {
+		context = {
+			...context,
+			[importAttributesProperty]: {
+				...(context[importAttributesProperty] ?? {}),
+				type: 'json',
+			},
+		};
+	}
+
+	const loaded = nextLoad(url, context);
+
+	const filePath = url.startsWith(fileUrlPrefix) ? fileURLToPath(url) : url;
+
+	if (
+		loaded.format === 'commonjs'
+		&& isFeatureSupported(esmLoadReadFile)
+		&& loaded.responseURL?.startsWith('file:')
+		&& !filePath.endsWith('.cjs')
+	) {
+		const code = readFileSync(new URL(url), 'utf8');
+
+		if (!filePath.endsWith('.js') || isESM(code)) {
+			const transformed = transformSync(
+				code,
+				filePath,
+				{
+					tsconfigRaw: (
+						data.parsedTsconfig && isFileIncluded(data.parsedTsconfig, filePath)
+							? data.parsedTsconfig.config as TransformOptions['tsconfigRaw']
+							: undefined
+					),
+				},
+			);
+
+			const filePathWithNamespace = urlNamespace ? `${filePath}?namespace=${encodeURIComponent(urlNamespace)}` : filePath;
+
+			loaded.responseURL = `data:text/javascript,${encodeURIComponent(transformed.code)}?filePath=${encodeURIComponent(filePathWithNamespace)}`;
+
+			return loaded;
+		}
+	}
+
+	if (!loaded.source) {
+		return loaded;
+	}
+
+	const code = loaded.source.toString();
+
+	if (
+		loaded.format === 'json'
+		|| tsExtensionsPattern.test(url)
+	) {
+		const transformed = transformEsmSync(
+			code,
+			filePath,
+			{
+				tsconfigRaw: (
+					data.parsedTsconfig && isFileIncluded(data.parsedTsconfig, filePath)
+						? data.parsedTsconfig.config as TransformOptions['tsconfigRaw']
+						: undefined
+				),
+			},
+		);
+
+		return {
+			format: 'module',
+			source: inlineSourceMap(transformed),
+		};
+	}
+
+	if (loaded.format === 'module') {
+		const dynamicImportTransformed = transformDynamicImport(filePath, code);
+		if (dynamicImportTransformed) {
+			loaded.source = inlineSourceMap(dynamicImportTransformed);
+		}
+	}
+
+	return loaded;
+};

--- a/src/esm/hook/package-json.ts
+++ b/src/esm/hook/package-json.ts
@@ -65,3 +65,56 @@ export const getPackageType = async (
 	const packageJson = await findPackageJson(filePath);
 	return packageJson?.type ?? 'commonjs';
 };
+
+const readPackageJsonSync = (filePath: string) => {
+	if (packageJsonCache.has(filePath)) {
+		return packageJsonCache.get(filePath);
+	}
+
+	if (!fs.existsSync(filePath)) {
+		packageJsonCache.set(filePath, undefined);
+		return;
+	}
+
+	const packageJsonString = fs.readFileSync(filePath, 'utf8');
+	try {
+		const packageJson = JSON.parse(packageJsonString) as PackageJson;
+		packageJsonCache.set(filePath, packageJson);
+		return packageJson;
+	} catch {
+		throw new Error(`Error parsing: ${filePath}`);
+	}
+};
+
+const findPackageJsonSync = (
+	filePath: string,
+) => {
+	let packageJsonUrl = new URL('package.json', filePath);
+
+	while (true) {
+		if (packageJsonUrl.pathname.endsWith('/node_modules/package.json')) {
+			break;
+		}
+
+		const packageJsonPath = fileURLToPath(packageJsonUrl);
+		const packageJson = readPackageJsonSync(packageJsonPath);
+
+		if (packageJson) {
+			return packageJson;
+		}
+
+		const lastPackageJSONUrl = packageJsonUrl;
+		packageJsonUrl = new URL('../package.json', packageJsonUrl);
+
+		if (packageJsonUrl.pathname === lastPackageJSONUrl.pathname) {
+			break;
+		}
+	}
+};
+
+export const getPackageTypeSync = (
+	filePath: string,
+) => {
+	const packageJson = findPackageJsonSync(filePath);
+	return packageJson?.type ?? 'commonjs';
+};

--- a/src/esm/hook/resolve.ts
+++ b/src/esm/hook/resolve.ts
@@ -3,9 +3,10 @@ import { pathToFileURL } from 'node:url';
 import type {
 	ResolveHook,
 	ResolveHookContext,
+	ResolveFnOutput,
+	ResolveHookSync,
 } from 'node:module';
 import type { PackageJson } from 'type-fest';
-import { resolvePathAlias } from 'get-tsconfig';
 import { readJsonFile } from '../../utils/read-json-file.js';
 import { mapTsExtensions } from '../../utils/map-ts-extensions.js';
 import type { NodeError } from '../../types.js';
@@ -20,12 +21,16 @@ import type { TsxRequest } from '../types.js';
 import { logEsm as log, debugEnabled } from '../../utils/debug.js';
 import {
 	getFormatFromFileUrl,
+	getFormatFromFileUrlSync,
 	namespaceQuery,
 	getNamespace,
 } from './utils.js';
 import { data } from './initialize.js';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const resolvePathAlias: typeof import('get-tsconfig')['resolvePathAlias'] = (...args) => (require('get-tsconfig') as typeof import('get-tsconfig')).resolvePathAlias(...args);
 
 type NextResolve = Parameters<ResolveHook>[2];
+type NextResolveSync = Parameters<ResolveHookSync>[2];
 
 const getMissingPathFromNotFound = (
 	nodeError: NodeError,
@@ -389,3 +394,221 @@ if (debugEnabled) {
 }
 
 export { resolve };
+
+const resolveExtensionsSync = (
+	url: string,
+	context: ResolveHookContext,
+	nextResolve: NextResolveSync,
+	throwError?: boolean,
+) => {
+	const tryPaths = mapTsExtensions(url);
+	if (!tryPaths) return;
+
+	let caughtError: unknown;
+	for (const tsPath of tryPaths) {
+		try {
+			return nextResolve(tsPath, context);
+		} catch (error) {
+			const { code } = error as NodeError;
+			if (
+				code !== 'ERR_MODULE_NOT_FOUND'
+				&& code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+			) {
+				throw error;
+			}
+			caughtError = error;
+		}
+	}
+
+	if (throwError) {
+		throw caughtError;
+	}
+};
+
+const resolveBaseSync = (
+	specifier: string,
+	context: ResolveHookContext,
+	nextResolve: NextResolveSync,
+) => {
+	const allowJs = data.parsedTsconfig?.config.compilerOptions?.allowJs ?? false;
+
+	if (
+		(
+			specifier.startsWith(fileUrlPrefix)
+			|| isRelativePath(specifier)
+		) && (
+			tsExtensionsPattern.test(context.parentURL!)
+			|| allowJs
+		)
+	) {
+		const resolved = resolveExtensionsSync(specifier, context, nextResolve);
+		if (resolved) {
+			return resolved;
+		}
+	}
+
+	try {
+		return nextResolve(specifier, context);
+	} catch (error) {
+		if (error instanceof Error) {
+			const nodeError = error as NodeError;
+			if (nodeError.code === 'ERR_MODULE_NOT_FOUND') {
+				const errorPath = getMissingPathFromNotFound(nodeError);
+				if (errorPath) {
+					const resolved = resolveExtensionsSync(errorPath, context, nextResolve);
+					if (resolved) {
+						return resolved;
+					}
+				}
+			}
+		}
+		throw error;
+	}
+};
+
+const resolveDirectorySync = (
+	specifier: string,
+	context: ResolveHookContext,
+	nextResolve: NextResolveSync,
+) => {
+	if (specifier === '.' || specifier === '..' || specifier.endsWith('/..')) {
+		specifier += '/';
+	}
+
+	if (isDirectoryPattern.test(specifier)) {
+		const urlParsed = new URL(specifier, context.parentURL);
+		urlParsed.pathname = path.join(urlParsed.pathname, 'index');
+		return resolveExtensionsSync(
+			urlParsed.toString(),
+			context,
+			nextResolve,
+			true,
+		)!;
+	}
+
+	try {
+		return resolveBaseSync(specifier, context, nextResolve);
+	} catch (error) {
+		if (error instanceof Error) {
+			const nodeError = error as NodeError;
+			if (nodeError.code === 'ERR_UNSUPPORTED_DIR_IMPORT') {
+				const errorPath = getMissingPathFromNotFound(nodeError);
+				if (errorPath) {
+					try {
+						return resolveExtensionsSync(
+							`${errorPath}/index`,
+							context,
+							nextResolve,
+							true,
+						)!;
+					} catch (_error) {
+						const __error = _error as Error;
+						const { message } = __error;
+						__error.message = __error.message.replace(`${'/index'.replace('/', path.sep)}'`, "'");
+						__error.stack = __error.stack!.replace(message, __error.message);
+						throw __error;
+					}
+				}
+			}
+		}
+		throw error;
+	}
+};
+
+const resolveTsPathsSync = (
+	specifier: string,
+	context: ResolveHookContext,
+	nextResolve: NextResolveSync,
+) => {
+	if (
+		!requestAcceptsQuery(specifier)
+		&& data.parsedTsconfig
+		&& !context.parentURL?.includes('/node_modules/')
+	) {
+		const possiblePaths = resolvePathAlias(data.parsedTsconfig, specifier);
+		for (const possiblePath of possiblePaths) {
+			try {
+				return resolveDirectorySync(
+					pathToFileURL(possiblePath).toString(),
+					context,
+					nextResolve,
+				);
+			} catch {}
+		}
+	}
+
+	return resolveDirectorySync(specifier, context, nextResolve);
+};
+
+export const resolveSync = (
+	specifier: string,
+	context: ResolveHookContext,
+	nextResolve: NextResolveSync,
+) => {
+	if (!data.active || specifier.startsWith('node:')) {
+		return nextResolve(specifier, context);
+	}
+
+	let requestNamespace = getNamespace(specifier) ?? (
+		context.parentURL && getNamespace(context.parentURL)
+	);
+
+	if (data.namespace) {
+		let tsImportRequest: TsxRequest | undefined;
+
+		if (specifier.startsWith(tsxProtocol)) {
+			try {
+				tsImportRequest = JSON.parse(specifier.slice(tsxProtocol.length));
+			} catch {}
+
+			if (tsImportRequest?.namespace) {
+				requestNamespace = tsImportRequest.namespace;
+			}
+		}
+
+		if (data.namespace !== requestNamespace) {
+			return nextResolve(specifier, context);
+		}
+
+		if (tsImportRequest) {
+			specifier = tsImportRequest.specifier;
+			context.parentURL = tsImportRequest.parentURL;
+		}
+	}
+
+	const [cleanSpecifier, query] = specifier.split('?');
+
+	const resolved = resolveTsPathsSync(
+		cleanSpecifier,
+		context,
+		nextResolve,
+	);
+
+	if (resolved.format === 'builtin') {
+		return resolved;
+	}
+
+	if (
+		(
+			!resolved.format
+			|| resolved.format === 'commonjs-typescript'
+			|| resolved.format === 'module-typescript'
+		)
+		&& resolved.url.startsWith(fileUrlPrefix)
+	) {
+		resolved.format = getFormatFromFileUrlSync(resolved.url);
+	}
+
+	if (query) {
+		resolved.url += `?${query}`;
+	}
+
+	if (
+		requestNamespace
+		&& !resolved.url.includes(namespaceQuery)
+	) {
+		resolved.url += (resolved.url.includes('?') ? '&' : '?') + namespaceQuery + requestNamespace;
+	}
+
+	return resolved;
+};

--- a/src/esm/hook/utils.ts
+++ b/src/esm/hook/utils.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { tsExtensions } from '../../utils/path-utils.js';
-import { getPackageType } from './package-json.js';
+import { getPackageType, getPackageTypeSync } from './package-json.js';
 
 export const getFormatFromFileUrl = (fileUrl: string) => {
 	const { pathname } = new URL(fileUrl);
@@ -14,6 +14,21 @@ export const getFormatFromFileUrl = (fileUrl: string) => {
 
 	if (extension === '.js' || tsExtensions.includes(extension)) {
 		return getPackageType(fileUrl);
+	}
+};
+
+export const getFormatFromFileUrlSync = (fileUrl: string) => {
+	const { pathname } = new URL(fileUrl);
+	const extension = path.extname(pathname);
+	if (extension === '.mts' || extension === '.mjs') {
+		return 'module';
+	}
+	if (extension === '.cts' || extension === '.cjs') {
+		return 'commonjs';
+	}
+
+	if (extension === '.js' || tsExtensions.includes(extension)) {
+		return getPackageTypeSync(fileUrl);
 	}
 };
 

--- a/src/utils/transform/index.ts
+++ b/src/utils/transform/index.ts
@@ -110,6 +110,53 @@ export const transformSync = (
 	return transformed;
 };
 
+
+// Used by esm sync hook (registerHooks) — ESM format, no __filename banner
+export const transformEsmSync = (
+	code: string,
+	filePath: string,
+	extendOptions?: TransformOptions,
+): Transformed => {
+	const esbuildOptions = {
+		...cacheConfig,
+		format: 'esm',
+		sourcefile: filePath,
+		...extendOptions,
+	} as const;
+
+	const hash = sha1([
+		code,
+		JSON.stringify(esbuildOptions),
+		esbuildVersion,
+		transformDynamicImportVersion,
+	].join('-'));
+	let transformed = cache.get(hash);
+
+	if (!transformed) {
+		transformed = applyTransformersSync(
+			filePath,
+			code,
+			[
+				(_filePath, _code) => {
+					const patchResult = patchOptions(esbuildOptions);
+					let result;
+					try {
+						result = esbuildTransformSync(_code, esbuildOptions);
+					} catch (error) {
+						throw formatEsbuildError(error as TransformFailure);
+					}
+					return patchResult(result);
+				},
+				(_filePath, _code) => transformDynamicImport(_filePath, _code, true),
+			],
+		);
+
+		cache.set(hash, transformed);
+	}
+
+	return transformed;
+};
+
 // Used by esm-loader
 export const transform = async (
 	code: string,

--- a/src/utils/tsconfig.ts
+++ b/src/utils/tsconfig.ts
@@ -1,8 +1,10 @@
-import { getTsconfig, readTsconfig, type TsconfigResult } from 'get-tsconfig';
+import type { TsconfigResult } from 'get-tsconfig';
 
 export const loadTsconfig = (
 	configPath?: string,
 ): TsconfigResult | undefined => {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const { getTsconfig, readTsconfig } = require('get-tsconfig') as typeof import('get-tsconfig');
 	if (configPath) {
 		return readTsconfig(configPath);
 	}

--- a/tests/utils/node-versions.ts
+++ b/tests/utils/node-versions.ts
@@ -13,6 +13,7 @@ export const nodeVersions = [
 			&& process.platform !== 'win32'
 		)
 			? [
+				latestMajor('26.1.0'),
 				latestMajor('22.6.0'),
 				latestMajor('21.7.3'),
 				latestMajor('20.17.0'),


### PR DESCRIPTION
Fixes #791. Node 26 promoted DEP0205 to runtime deprecation. To solve this without regressing TSX's core features (like tsconfig paths and dynamic imports), this PR exposes fully synchronous variants of the ESM hook loader specifically for the new registerHooks API.