### PR TITLE
fix: preserve CJS bridge JSON requires

### DIFF
--- a/src/esm/hook/load.ts
+++ b/src/esm/hook/load.ts
@@ -244,11 +244,24 @@ const prepareJsonAttributes = (
 	};
 };
 
+const commonJsFromEsmBridgeStackFrame = 'loadAndTranslateForRequireInImportedCJS';
+
 const isCommonJsRequireContext = (
 	{ conditions }: Parameters<LoadHook>[1],
 ) => (
 	conditions?.includes('require') === true
 	&& !conditions.includes('import')
+);
+
+const isCommonJsFromEsmBridgeRequireContext = (
+	{ conditions }: Parameters<LoadHook>[1],
+) => (
+	// Yarn PnP on Node 24+ can send `import` conditions for JSON required
+	// by a CommonJS module reached through the ESM->CJS bridge. Node still
+	// parses the hook result as JSON on that path, so transforming it to ESM
+	// breaks the CommonJS consumer.
+	conditions?.includes('import') === true
+	&& new Error('Detect CommonJS JSON require bridge').stack?.includes(commonJsFromEsmBridgeStackFrame) === true
 );
 
 export const createLoad = (
@@ -377,7 +390,11 @@ export const createLoad = (
 		const code = decodeSource(loaded.source);
 		// CJS JSON require still parses hook source as JSON after module hooks.
 		// https://github.com/nodejs/node/blob/v24.15.0/lib/internal/modules/cjs/loader.js#L1969-L1978
-		const shouldTransformJson = loadedFormat === 'json' && !isCommonJsRequireContext(context);
+		const shouldTransformJson = (
+			loadedFormat === 'json'
+			&& !isCommonJsRequireContext(context)
+			&& !isCommonJsFromEsmBridgeRequireContext(context)
+		);
 
 		if (loadedFormat === 'commonjs-typescript') {
 			const transformed = transformSync(
@@ -528,7 +545,11 @@ export const createLoadSync = (
 		const code = decodeSource(loaded.source);
 		// CJS JSON require still parses hook source as JSON after module hooks.
 		// https://github.com/nodejs/node/blob/v24.15.0/lib/internal/modules/cjs/loader.js#L1969-L1978
-		const shouldTransformJson = loadedFormat === 'json' && !isCommonJsRequireContext(context);
+		const shouldTransformJson = (
+			loadedFormat === 'json'
+			&& !isCommonJsRequireContext(context)
+			&& !isCommonJsFromEsmBridgeRequireContext(context)
+		);
 
 		if (loadedFormat === 'commonjs-typescript') {
 			const transformed = transformSync(

--- a/tests/specs/version-sensitive.ts
+++ b/tests/specs/version-sensitive.ts
@@ -6,6 +6,8 @@ import {
 } from 'manten';
 import { execaNode } from 'execa';
 import { createFixture } from 'fs-fixture';
+import { createData } from '../../src/esm/hook/initialize.js';
+import { createLoadSync } from '../../src/esm/hook/load.js';
 import { tsxEsmApiPath, tsxEsmPath, type NodeApis } from '../utils/tsx';
 import { createPackageJson } from '../fixtures';
 import { processInteract } from '../utils/process-interact.js';
@@ -309,6 +311,43 @@ export const versionSensitiveTests = (node: NodeApis) => describe('Version-sensi
 			expect(process.exitCode).toBe(0);
 			expect(process.stderr).toBe('');
 			expect(JSON.parse(process.stdout)).toEqual({
+				diff: true,
+				extension: ['js', 'cjs', 'mjs'],
+			});
+		});
+
+		test('sync ESM hook preserves ESM-to-CJS bridge JSON require', async () => {
+			await using fixture = await createFixture({
+				'mocharc.json': JSON.stringify({
+					diff: true,
+					extension: ['js', 'cjs', 'mjs'],
+				}),
+			});
+			const jsonUrl = pathToFileURL(fixture.getPath('mocharc.json')).toString();
+			const loadSync = createLoadSync(createData({ tsconfig: false }));
+
+			// Simulates Node's internal ESM->CJS bridge frame for JSON requires.
+			const loadAndTranslateForRequireInImportedCJS = () => loadSync(
+				jsonUrl,
+				{
+					conditions: ['node', 'import'],
+					format: 'json',
+					importAttributes: { type: 'json' },
+				},
+				() => ({
+					format: 'json',
+					responseURL: jsonUrl,
+					source: JSON.stringify({
+						diff: true,
+						extension: ['js', 'cjs', 'mjs'],
+					}),
+				}),
+			);
+
+			const loaded = loadAndTranslateForRequireInImportedCJS();
+
+			expect(loaded.format).toBe('json');
+			expect(JSON.parse(loaded.source as string)).toEqual({
 				diff: true,
 				extension: ['js', 'cjs', 'mjs'],
 			});


### PR DESCRIPTION
Fixes #797.

Yarn PnP hits a weird Node edge here: CJS `require()` for JSON goes through the sync ESM hook with `import` conditions. `tsx` was treating that as ESM JSON and breaking the CJS side.

Kept that bridge path as raw JSON and added regression coverage. Real Node bug is still nodejs/node#51327 - this is just the guard `tsx` can land.
