### PR TITLE
fix: isolate ESM hook state per module.register() registration

### DIFF
--- a/src/esm/api/register.ts
+++ b/src/esm/api/register.ts
@@ -37,6 +37,10 @@ export type Register = {
 
 let cjsInteropApplied = false;
 
+// Deduplicates same-millisecond registrations, which would otherwise reuse
+// the same cached loader module and share per-registration hook state
+let registrationCount = 0;
+
 const collectImportSpecifiers = (
 	argv: string[],
 ) => {
@@ -154,10 +158,12 @@ export const register: Register = (
 		return unregister;
 	}
 
+	registrationCount += 1;
+
 	const { port1, port2 } = new MessageChannel();
 	module.register(
 		// Load new copy of loader so it can be registered multiple times
-		`./esm/index.mjs?${Date.now()}`,
+		`./esm/index.mjs?${Date.now()}.${registrationCount}`,
 		{
 			parentURL: import.meta.url,
 			data: {

--- a/src/esm/hook/index.ts
+++ b/src/esm/hook/index.ts
@@ -1,3 +1,17 @@
-export { initialize, globalPreload } from './initialize.js';
-export { load } from './load.js';
-export { resolve } from './resolve.js';
+import { createInitialize, createGlobalPreload, type Data } from './initialize.js';
+import { createLoad } from './load.js';
+import { createResolve } from './resolve.js';
+
+export const createHooks = () => {
+	const data: Data = {
+		active: true,
+		parsedTsconfig: undefined,
+	};
+
+	return {
+		initialize: createInitialize(data),
+		globalPreload: createGlobalPreload(data),
+		load: createLoad(data),
+		resolve: createResolve(data),
+	};
+};

--- a/src/esm/hook/initialize.ts
+++ b/src/esm/hook/initialize.ts
@@ -10,11 +10,6 @@ type Data = InitializationOptions & {
 	parsedTsconfig: TsconfigResult | undefined;
 };
 
-export const data: Data = {
-	active: true,
-	parsedTsconfig: undefined,
-};
-
 export type { Data };
 
 export const createData = (
@@ -38,7 +33,9 @@ export const createData = (
 	return hookData;
 };
 
-export const initialize: InitializeHook = async (
+export const createInitialize = (
+	data: Data,
+): InitializeHook => async (
 	options?: InitializationOptions,
 ) => {
 	if (!options) {
@@ -61,7 +58,9 @@ export const initialize: InitializeHook = async (
 type GlobalPreloadHook = () => string;
 
 // Replaced by `initialize` in Node v20.6.0, v18.19.0
-export const globalPreload: GlobalPreloadHook = () => {
+export const createGlobalPreload = (
+	data: Data,
+): GlobalPreloadHook => () => {
 	data.parsedTsconfig = loadTsconfig(process.env.TSX_TSCONFIG_PATH);
 	return 'process.setSourceMapsEnabled(true);';
 };

--- a/src/esm/hook/load.ts
+++ b/src/esm/hook/load.ts
@@ -28,7 +28,7 @@ import {
 	getNamespace,
 	moduleSourceByUrl,
 } from './utils.js';
-import { data as defaultData, type Data } from './initialize.js';
+import type { Data } from './initialize.js';
 
 const importAttributesProperty = (
 	isFeatureSupported(importAttributes)
@@ -598,5 +598,3 @@ export const createLoadSync = (
 		return result;
 	};
 };
-
-export const load = createLoad(defaultData);

--- a/src/esm/hook/resolve.ts
+++ b/src/esm/hook/resolve.ts
@@ -32,7 +32,7 @@ import {
 	getNamespace,
 	parentImportsCommonJsExports,
 } from './utils.js';
-import { data as defaultData, type Data } from './initialize.js';
+import type { Data } from './initialize.js';
 
 type NextResolve = Parameters<ResolveHook>[2];
 type NextResolveSync = Parameters<ResolveHookSync>[2];
@@ -850,5 +850,3 @@ export const createResolveSync = (
 		return result;
 	};
 };
-
-export const resolve = createResolve(defaultData);

--- a/src/esm/index.ts
+++ b/src/esm/index.ts
@@ -4,6 +4,7 @@
 import * as workerThreads from 'node:worker_threads';
 import { isFeatureSupported, moduleRegister, moduleRegisterHooksCjsReload } from '../utils/node-features.js';
 import { register } from './api/index.js';
+import { createHooks } from './hook/index.js';
 
 // Loaded via --import flag
 if (
@@ -22,4 +23,13 @@ if (
 	register();
 }
 
-export * from './hook/index.js';
+// Hook state must live in this entry's module scope: module.register() loads
+// a new cache-busted copy of this entry per registration, but bundled chunks
+// it imports are shared and only evaluate once. State in a shared chunk would
+// be overwritten by every registration (namespaces clobbering each other).
+export const {
+	initialize,
+	globalPreload,
+	load,
+	resolve,
+} = createHooks();

--- a/tests/specs/version-sensitive.ts
+++ b/tests/specs/version-sensitive.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 import {
-	describe, test, expect, skip,
+	describe, test, expect, skip, onTestFail,
 } from 'manten';
 import { execaNode } from 'execa';
 import { createFixture } from 'fs-fixture';
@@ -887,6 +887,48 @@ export const versionSensitiveTests = (node: NodeApis) => describe('Version-sensi
 			},
 			plainLoaded: false,
 		});
+	});
+
+	test('tsImport propagates load errors across repeated registrations', async () => {
+		await using fixture = await createFixture({
+			'package.json': createPackageJson({ type: 'module' }),
+			'import.mjs': `
+				import { tsImport } from ${JSON.stringify(tsxEsmApiPath)};
+
+				for (let i = 1; i <= 6; i += 1) {
+					const result = await tsImport('./bad.ts', import.meta.url).then(
+						() => 'resolved',
+						error => \`rejected (\${error.code})\`,
+					);
+					console.log(\`call \${i}: \${result}\`);
+				}
+				console.log('done');
+				`,
+			'bad.ts': `
+				import icon from './icon.svg';
+				export default icon;
+				`,
+			'icon.svg': '<svg/>',
+		});
+
+		const process = await execaNode(fixture.getPath('import.mjs'), [], {
+			nodePath: node.path,
+			nodeOptions: ['--no-warnings'],
+			reject: false,
+
+			// Each registration multiplying resolution work manifests as a hang
+			// long before this timeout; the linear path finishes in seconds.
+			timeout: 30_000,
+		});
+		onTestFail(() => {
+			console.log(process);
+		});
+
+		expect(process.exitCode).toBe(0);
+		expect(process.stdout).toBe([
+			...Array.from({ length: 6 }, (_, i) => `call ${i + 1}: rejected (ERR_UNKNOWN_FILE_EXTENSION)`),
+			'done',
+		].join('\n'));
 	});
 
 	test('CJS namespace import shape depends on Node version', async () => {

--- a/tests/specs/version-sensitive.ts
+++ b/tests/specs/version-sensitive.ts
@@ -931,6 +931,59 @@ export const versionSensitiveTests = (node: NodeApis) => describe('Version-sensi
 		].join('\n'));
 	});
 
+	test('concurrent registrations keep their namespaces isolated', async () => {
+		await using fixture = await createFixture({
+			'package.json': createPackageJson({ type: 'module' }),
+			'import.mjs': `
+				import { register } from ${JSON.stringify(tsxEsmApiPath)};
+
+				const tag = url => new URL(url).searchParams.get('tsx-namespace');
+
+				// Both registrations stay active at once: registering the second
+				// must not overwrite the namespace the first routes on, and each
+				// hook must handle only its own namespace.
+				const one = register({ namespace: 'one' });
+				const two = register({ namespace: 'two' });
+
+				const first = await one.import('./module.ts', import.meta.url);
+				const second = await two.import('./module.ts', import.meta.url);
+
+				console.log(JSON.stringify({
+					first: { tag: tag(first.url), loadCount: first.loadCount },
+					second: { tag: tag(second.url), loadCount: second.loadCount },
+				}));
+				`,
+			'module.ts': `
+				globalThis.__loadCount = (globalThis.__loadCount ?? 0) + 1;
+				export const loadCount: number = globalThis.__loadCount;
+				export const url = import.meta.url;
+				`,
+		});
+
+		const process = await execaNode(fixture.getPath('import.mjs'), [], {
+			nodePath: node.path,
+			nodeOptions: ['--no-warnings'],
+			reject: false,
+		});
+		onTestFail(() => {
+			console.log(process);
+		});
+
+		expect(process.exitCode).toBe(0);
+		expect(JSON.parse(process.stdout)).toEqual({
+			// Each registration resolves the module under its own namespace, and
+			// the namespace query busts the cache so it evaluates once per namespace.
+			first: {
+				tag: 'one',
+				loadCount: 1,
+			},
+			second: {
+				tag: 'two',
+				loadCount: 2,
+			},
+		});
+	});
+
 	test('CJS namespace import shape depends on Node version', async () => {
 		await using fixture = await createFixture({
 			'package.json': createPackageJson({ type: 'module' }),


### PR DESCRIPTION
- `tsImport()` hangs once a failing import passes through 6 or more hook registrations on Node versions using the async `module.register()` path (below 24.11.1 / 25.1.0). Regressed in 4.22.0.
- The `api/register` module started importing the hook factories, which made the bundler move the hook module, including its mutable hook state singleton, into a shared chunk. The cache-busted loader entry re-evaluates per registration, but the shared chunk only evaluates once, so every `initialize()` overwrote the same namespace and active flag.
- With all chained registrations claiming the most recent namespace, each hook re-applied TypeScript extension guessing to the failed candidates of the hook above it, multiplying resolution work per registration. Failing imports never settled, and unregistering could not deactivate the shared state.


This PR:
- Creates hook state in the loader entry's module scope via a `createHooks()` factory so each registration owns its data, and drops the state-bound singleton exports from the hook modules.
- Suffixes the loader URL query with a counter so same-millisecond registrations cannot reuse the cached loader module and share state.
- Covers repeated failing `tsImport()` calls across registrations in version-sensitive tests.

Fixes #806 