### PR TITLE
fix: avoid redundant filesystem probes during module resolution

### DIFF
--- a/src/utils/map-ts-extensions.ts
+++ b/src/utils/map-ts-extensions.ts
@@ -1,5 +1,10 @@
 import path from 'node:path';
-import { isFilePath, fileUrlPrefix, nodeModulesPath } from './path-utils.js';
+import {
+	isFilePath,
+	fileUrlPrefix,
+	nodeModulesPath,
+	tsExtensionsPattern,
+} from './path-utils.js';
 
 const implicitJsExtensions = ['.js', '.json'];
 const implicitTsExtensions = ['.ts', '.tsx', '.jsx'];
@@ -30,23 +35,42 @@ export const mapTsExtensions = (
 	const [pathname] = splitPath;
 	const extension = path.extname(pathname);
 
-	const tryPaths: string[] = [];
-
+	/**
+	 * Swappable JS extension (.js/.jsx/.cjs/.mjs): try the TypeScript
+	 * equivalents first, then the original (the swap list includes it).
+	 *
+	 * We intentionally don't also append extensions to the full path
+	 * (e.g. `foo.js.ts`) — such files don't exist in practice, and each
+	 * non-existent candidate forces Node's resolver to probe a whole family
+	 * of paths (extension + directory/index lookups), which is the main
+	 * source of redundant fs `stat` calls during resolution.
+	 */
 	const tryExtensions = tsExtensions[extension];
 	if (tryExtensions) {
 		const extensionlessPath = pathname.slice(0, -extension.length);
-
-		tryPaths.push(
-			...tryExtensions.map(
-				extension_ => (
-					extensionlessPath
-					+ extension_
-					+ pathQuery
-				),
+		return tryExtensions.map(
+			extension_ => (
+				extensionlessPath
+				+ extension_
+				+ pathQuery
 			),
 		);
 	}
 
+	/**
+	 * Explicit TypeScript extension (.ts/.tsx/.cts/.mts): the path already
+	 * points at the file, so resolve it as-is instead of appending extensions
+	 * (e.g. `foo.ts.ts`). This is the dominant case for projects that import
+	 * with explicit extensions, and previously generated only dead candidates.
+	 */
+	if (tsExtensionsPattern.test(pathname)) {
+		return [pathname + pathQuery];
+	}
+
+	/**
+	 * Otherwise (extensionless, or an unrecognized extension): guess the
+	 * extension. Dependencies prioritize .js over .ts.
+	 */
 	const guessExtensions = (
 		(
 			!(filePath.startsWith(fileUrlPrefix) || isFilePath(pathname))
@@ -56,15 +80,11 @@ export const mapTsExtensions = (
 			? dependencyExtensions
 			: localExtensions
 	);
-	tryPaths.push(
-		...guessExtensions.map(
-			extension_ => (
-				pathname
-				+ extension_
-				+ pathQuery
-			),
+	return guessExtensions.map(
+		extension_ => (
+			pathname
+			+ extension_
+			+ pathQuery
 		),
 	);
-
-	return tryPaths;
 };

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -10,6 +10,7 @@ import { repl } from './specs/repl';
 import { processInteractSpec } from './specs/process-interact';
 import { tsconfig } from './specs/tsconfig';
 import { transformSpec } from './specs/transform';
+import { mapTsExtensionsSpec } from './specs/map-ts-extensions';
 import { commonJsModeContracts } from './specs/commonjs-mode-contracts';
 import { nodeCapabilitiesSpec } from './specs/node-capabilities';
 import { versionSensitiveTests } from './specs/version-sensitive';
@@ -22,6 +23,7 @@ import { versionSensitiveTests } from './specs/version-sensitive';
 		await repl();
 		await processInteractSpec();
 		await transformSpec();
+		await mapTsExtensionsSpec();
 		await nodeCapabilitiesSpec();
 
 		const [primaryNodeVersion, ...compatNodeVersions] = nodeVersions;

--- a/tests/specs/map-ts-extensions.ts
+++ b/tests/specs/map-ts-extensions.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from 'manten';
+import { mapTsExtensions } from '../../src/utils/map-ts-extensions.js';
+
+// A candidate that ends in two module extensions (e.g. `foo.ts.ts`, `foo.js.tsx`)
+// can never exist for a normally-authored import. Generating one makes the
+// resolver probe a whole dead branch of the filesystem.
+const doubledExtension = /\.[cm]?[jt]sx?\.[cm]?[jt]sx?(\?|$)/;
+
+export const mapTsExtensionsSpec = () => describe('mapTsExtensions', () => {
+	test('explicit TypeScript extension resolves as-is', () => {
+		expect(mapTsExtensions('./foo.ts')).toStrictEqual(['./foo.ts']);
+		expect(mapTsExtensions('./foo.tsx')).toStrictEqual(['./foo.tsx']);
+		expect(mapTsExtensions('./foo.cts')).toStrictEqual(['./foo.cts']);
+		expect(mapTsExtensions('./foo.mts')).toStrictEqual(['./foo.mts']);
+	});
+
+	test('preserves the query string', () => {
+		expect(mapTsExtensions('./foo.ts?key=value')).toStrictEqual(['./foo.ts?key=value']);
+		expect(mapTsExtensions('./foo.js?key=value')).toStrictEqual([
+			'./foo.ts?key=value',
+			'./foo.tsx?key=value',
+			'./foo.js?key=value',
+			'./foo.jsx?key=value',
+		]);
+	});
+
+	test('swaps JS extensions for TypeScript equivalents', () => {
+		expect(mapTsExtensions('./foo.js')).toStrictEqual([
+			'./foo.ts',
+			'./foo.tsx',
+			'./foo.js',
+			'./foo.jsx',
+		]);
+		expect(mapTsExtensions('./foo.jsx')).toStrictEqual([
+			'./foo.tsx',
+			'./foo.ts',
+			'./foo.jsx',
+			'./foo.js',
+		]);
+	});
+
+	test('guesses extensions for extensionless local files (TypeScript first)', () => {
+		expect(mapTsExtensions('./foo')).toStrictEqual([
+			'./foo.ts',
+			'./foo.tsx',
+			'./foo.jsx',
+			'./foo.js',
+			'./foo.json',
+		]);
+	});
+
+	test('guesses extensions for dependencies (JavaScript first)', () => {
+		expect(mapTsExtensions('foo')).toStrictEqual([
+			'foo.js',
+			'foo.json',
+			'foo.ts',
+			'foo.tsx',
+			'foo.jsx',
+		]);
+	});
+
+	test('never emits dead candidates with doubled extensions', () => {
+		const requests = [
+			'./foo.ts',
+			'./foo.tsx',
+			'./foo.cts',
+			'./foo.mts',
+			'./foo.js',
+			'./foo.jsx',
+			'./foo.cjs',
+			'./foo.mjs',
+		];
+		for (const request of requests) {
+			for (const candidate of mapTsExtensions(request)) {
+				expect(candidate).not.toMatch(doubledExtension);
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Overview

Fixes a startup-time performance regression: tsx probes far more filesystem paths than necessary when resolving imports, especially under the synchronous module hooks used on Node >= 24.11.1 (the path #809 bisected to in `1d7e528`).

The regression occurs because `mapTsExtensions` appends extension guesses even when the specifier has an explicit extension, leading to wasted time probing unlikely paths. For example:
- `import './config.ts'` → tries `config.ts.ts`, `config.ts.tsx`, `config.ts.jsx`, `config.ts.js`, `config.ts.json` before falling through to the real file.
- `import './foo.js'` → in addition to the desired `.js`→`.ts` check, also tries `foo.js.ts`, `foo.js.tsx`, etc.

Under the sync `registerHooks` resolver, each missing candidate further makes Node run a full CommonJS-style probe (`+.js/.json/.node/.ts/.tsx/.jsx` and `/index.*`). So a project with a single `import './leaf.ts'` issues 87 `stat` calls against its own files: 12 after this change, and 33 on 4.21.0. Projects that import with explicit extensions are particularly affected, e.g. [the repository](https://github.com/survev/survev/) linked to #809.

I had also previously noticed this [while investigating issue #640](https://github.com/privatenumber/tsx/issues/640#issuecomment-2472806032). 

## Fix

In `mapTsExtensions`:
- **Explicit TS extension** (`.ts/.tsx/.cts/.mts`) → resolve as-is, no appended guesses.
- **Swappable JS extension** (`.js/.jsx/.cjs/.mjs`) → return the swap list only; don't also append to the full path.
- **Extensionless / unknown** → guess as before (dependency `.js`-before-`.ts` ordering preserved).

## Performance

While investigating, performance was measured using two synthetic projects - one a single file import, the other a 400-module project. The counts in the following table are stat-family syscalls (`statx`/`newfstatat`/`stat`/`lstat`) issued against the project's own files, on Node 24.16.0 (Node/esbuild startup excluded).

| scenario | before (master) | after | old 4.21.0 |
|---|---|---|---|
| 400-module project, explicit `.ts` imports | 30,811 | 811 | 10,807 |
| single `import './leaf.ts'` | 87 | 12 | 33 |



