### PR TITLE
fix: don't extend allowJs resolution into node_modules (ESM + CommonJS)

### DIFF
--- a/src/cjs/api/module-resolve-filename/index.ts
+++ b/src/cjs/api/module-resolve-filename/index.ts
@@ -94,7 +94,12 @@ export const createResolveFilename = (
 			// If parent is a TS file
 			|| (parent?.filename && tsExtensionsPattern.test(parent.filename)),
 		),
-		tsconfig?.config.compilerOptions?.allowJs ?? false,
+		// `allowJs` applies TypeScript-first resolution to local files only.
+		// Imports from inside node_modules are dependencies: their requested
+		// path should win (published packages ship runnable .js), so don't
+		// probe TypeScript extensions for them.
+		(tsconfig?.config.compilerOptions?.allowJs ?? false)
+		&& !parent?.filename?.includes(nodeModulesPath),
 	);
 
 	nextResolveSimple = createImplicitResolver(nextResolveSimple);

--- a/src/esm/hook/resolve.ts
+++ b/src/esm/hook/resolve.ts
@@ -203,7 +203,10 @@ const resolveBase = async (
 	 * TS aliases are pre-resolved so they're file paths
 	 *
 	 * If `allowJs` is set in `tsconfig.json`, then we'll apply the same resolution logic
-	 * to files without a TypeScript extension.
+	 * to files without a TypeScript extension — but only for local files. Imports from
+	 * inside `node_modules` are dependencies: their requested path should win, and
+	 * speculatively probing TypeScript extensions first balloons fs lookups for every
+	 * dependency module without ever resolving one (they ship .js, not .ts).
 	 */
 	if (
 		(
@@ -211,7 +214,7 @@ const resolveBase = async (
 			|| isRelativePath(specifier)
 		) && (
 			tsExtensionsPattern.test(context.parentURL!)
-			|| allowJs
+			|| (allowJs && !context.parentURL?.includes('/node_modules/'))
 		)
 	) {
 		const resolved = await resolveExtensions(specifier, context, nextResolve);
@@ -274,7 +277,7 @@ const resolveBaseSync = (
 			|| isRelativePath(specifier)
 		) && (
 			tsExtensionsPattern.test(context.parentURL!)
-			|| allowJs
+			|| (allowJs && !context.parentURL?.includes('/node_modules/'))
 		)
 	) {
 		const resolved = resolveExtensionsSync(specifier, context, nextResolve);

--- a/tests/specs/tsconfig.ts
+++ b/tests/specs/tsconfig.ts
@@ -256,4 +256,39 @@ export const tsconfig = ({ tsx }: NodeApis) => describe('tsconfig', () => {
 			});
 		});
 	}
+
+	describe('allowJs does not redirect dependency imports to TypeScript files', async () => {
+		// A dependency's own relative `.js` import must resolve to that `.js`,
+		// even when the project enables `allowJs`. Prioritizing TypeScript
+		// extensions for imports made from inside node_modules would load the
+		// decoy `.ts` instead (and probe many dead paths getting there).
+		const fixture = await createFixture({
+			'package.json': createPackageJson({ type: 'module' }),
+			'tsconfig.json': createTsconfig({ compilerOptions: { allowJs: true } }),
+			'index.ts': 'import { value } from \'dependency\';\nconsole.log(value);',
+			node_modules: {
+				dependency: {
+					'package.json': createPackageJson({
+						name: 'dependency',
+						type: 'module',
+						exports: './index.js',
+					}),
+					'index.js': 'export { value } from \'./value.js\';',
+					'value.js': 'export const value = \'from-dependency-js\';',
+					'value.ts': 'export const value = \'from-decoy-ts\';',
+				},
+			},
+		});
+		onFinish(async () => await fixture.rm());
+
+		test('resolves the dependency .js over a sibling .ts', async () => {
+			const p = await tsx(['index.ts'], fixture.path);
+			onTestFail((error) => {
+				console.error(error);
+				console.log(p);
+			});
+			expect(p.exitCode).toBe(0);
+			expect(p.stdout).toBe('from-dependency-js');
+		});
+	});
 });

--- a/tests/specs/tsconfig.ts
+++ b/tests/specs/tsconfig.ts
@@ -262,14 +262,16 @@ export const tsconfig = ({ tsx }: NodeApis) => describe('tsconfig', () => {
 		// even when the project enables `allowJs`. Prioritizing TypeScript
 		// extensions for imports made from inside node_modules would load the
 		// decoy `.ts` instead (and probe many dead paths getting there).
+		// Covers both resolvers: the ESM hook and the CommonJS resolver.
 		const fixture = await createFixture({
 			'package.json': createPackageJson({ type: 'module' }),
 			'tsconfig.json': createTsconfig({ compilerOptions: { allowJs: true } }),
-			'index.ts': 'import { value } from \'dependency\';\nconsole.log(value);',
+			'esm.ts': 'import { value } from \'esm-dependency\';\nconsole.log(value);',
+			'cjs.cts': 'console.log(require(\'cjs-dependency\').value);',
 			node_modules: {
-				dependency: {
+				'esm-dependency': {
 					'package.json': createPackageJson({
-						name: 'dependency',
+						name: 'esm-dependency',
 						type: 'module',
 						exports: './index.js',
 					}),
@@ -277,12 +279,31 @@ export const tsconfig = ({ tsx }: NodeApis) => describe('tsconfig', () => {
 					'value.js': 'export const value = \'from-dependency-js\';',
 					'value.ts': 'export const value = \'from-decoy-ts\';',
 				},
+				'cjs-dependency': {
+					'package.json': createPackageJson({
+						name: 'cjs-dependency',
+						main: 'index.js',
+					}),
+					'index.js': 'module.exports = require(\'./value\');',
+					'value.js': 'module.exports = { value: \'from-dependency-js\' };',
+					'value.ts': 'export const value = \'from-decoy-ts\';',
+				},
 			},
 		});
 		onFinish(async () => await fixture.rm());
 
-		test('resolves the dependency .js over a sibling .ts', async () => {
-			const p = await tsx(['index.ts'], fixture.path);
+		test('ESM dependency resolves its own .js over a sibling .ts', async () => {
+			const p = await tsx(['esm.ts'], fixture.path);
+			onTestFail((error) => {
+				console.error(error);
+				console.log(p);
+			});
+			expect(p.exitCode).toBe(0);
+			expect(p.stdout).toBe('from-dependency-js');
+		});
+
+		test('CommonJS dependency resolves its own .js over a sibling .ts', async () => {
+			const p = await tsx(['cjs.cts'], fixture.path);
 			onTestFail((error) => {
 				console.error(error);
 				console.log(p);


### PR DESCRIPTION
## Overview

With `allowJs`, tsx will resolve `.ts`/`.tsx` ahead of a requested `.js` specifier. This is usually the right heuristic for local code. In contrast, packages installed from npm or otherwise present in `node_modules` should be expected to have been transpiled already, and there's no guarantee that a `value.ts` alongside `value.js` will necessarily be transpiled correctly by tsx. Nevertheless, tsx picks the sibling `value.ts` over the dependency's own `value.js`.

This is the class of bug behind #640. It was originally diagnosed (in 2024, on tsx 4.16.3) as libphonenumber-js's internal `require('../metadata.min.json')` resolving to a sibling `metadata.min.json.js` (an ES module), so the metadata arrived as `{ default: … }` and validation threw `Got an object of shape: { default }`. The minimal reproduction below demonstrates the same principle deterministically. The real point is that tsx should not be second-guessing a dependency's own resolution process.

## Issue Reproduction

Minimal reproduction — a dependency whose entry imports `./value`, shipping both its real `value.js` and a stray `value.ts`:

```
node_modules/dep/index.js   // require('./value')  (or  export … from './value.js')
node_modules/dep/value.js   // the file the package actually ships
node_modules/dep/value.ts   // an unrelated sibling
```

With `allowJs`, tsx loads `value.ts`; it should load `value.js`

## Fix

Restrict `allowJs`'s TypeScript-first resolution to local files in the ESM hook (`resolveBase`/`resolveBaseSync`) and the CommonJS resolver (`createResolveFilename`) by excluding parents under `node_modules`. The CommonJS resolver already applies this exclusion to tsconfig path aliases; this brings extension resolution in line.

## Timeline

- `allowJs` TypeScript resolution shipped in **v4.7.3** (#535, `081853e`).
- The dependency-resolution rework in **v4.16.3** (`3df00f4`, "prioritize requested path in dependencies") extended it through the **CommonJS** resolver, introducing the regression #640 reports.
- Issue persists in both resolvers through the latest release (**v4.22.4**).

