### PR TITLE
fix: surface readable error for invalid --tsconfig path

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -2,6 +2,7 @@ import type { StdioOptions } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import spawn from 'cross-spawn';
 import { isFeatureSupported, moduleRegister } from './utils/node-features.js';
+import { loadTsconfig } from './utils/tsconfig.js';
 
 export const run = (
 	argv: string[],
@@ -29,6 +30,17 @@ export const run = (
 		}
 
 		if (options.tsconfigPath) {
+			// Validate the explicitly passed tsconfig in the parent process so a
+			// missing or unreadable file surfaces as a readable error here, instead
+			// of an unreadable stack trace thrown from the minified child loader.
+			try {
+				loadTsconfig(options.tsconfigPath);
+			} catch (error) {
+				console.error((error as Error).message);
+				// eslint-disable-next-line n/no-process-exit
+				process.exit(1);
+			}
+
 			environment.TSX_TSCONFIG_PATH = options.tsconfigPath;
 		}
 	}

--- a/src/utils/tsconfig.ts
+++ b/src/utils/tsconfig.ts
@@ -1,10 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { getTsconfig, readTsconfig, type TsconfigResult } from 'get-tsconfig';
 
 export const loadTsconfig = (
 	configPath?: string,
 ): TsconfigResult | undefined => {
 	if (configPath) {
-		return readTsconfig(configPath);
+		const resolvedConfigPath = path.resolve(configPath);
+		if (!fs.existsSync(resolvedConfigPath)) {
+			throw new Error(`Cannot find tsconfig at path: ${resolvedConfigPath}`);
+		}
+
+		try {
+			return readTsconfig(resolvedConfigPath);
+		} catch (error) {
+			throw new Error(`Failed to read tsconfig at: ${resolvedConfigPath}\n${(error as Error).message}`);
+		}
 	}
 
 	try {

--- a/tests/specs/tsconfig.ts
+++ b/tests/specs/tsconfig.ts
@@ -232,6 +232,31 @@ export const tsconfig = ({ tsx }: NodeApis) => describe('tsconfig', () => {
 					expect(pTsconfig.failed).toBe(true);
 				});
 
+				test('missing tsconfig errors with a readable message', async () => {
+					const pTsconfig = await tsx(['--tsconfig', 'missing.json', 'index.tsx'], fixture.path);
+					onTestFail((error) => {
+						console.error(error);
+						console.log(pTsconfig);
+					});
+					expect(pTsconfig.failed).toBe(true);
+					expect(pTsconfig.stderr).toMatch('Cannot find tsconfig at path:');
+					// The minified parser source should not be dumped as an unreadable stack trace
+					expect(pTsconfig.stderr).not.toMatch('onObjectBegin');
+					expect(pTsconfig.stdout).toBe('');
+				});
+
+				test('unresolvable tsconfig errors with a readable message', async () => {
+					const pTsconfig = await tsx(['--tsconfig', 'tsconfig-unresolvable.json', 'index.tsx'], fixture.path);
+					onTestFail((error) => {
+						console.error(error);
+						console.log(pTsconfig);
+					});
+					expect(pTsconfig.failed).toBe(true);
+					expect(pTsconfig.stderr).toMatch('Failed to read tsconfig at:');
+					expect(pTsconfig.stderr).not.toMatch('onObjectBegin');
+					expect(pTsconfig.stdout).toBe('');
+				});
+
 				test('custom tsconfig', async () => {
 					const pTsconfigAllowJs = await tsx(['--tsconfig', 'tsconfig-allowJs.json', 'jsx.jsx'], fixture.path);
 					onTestFail((error) => {


### PR DESCRIPTION
## Linked issue

Closes #779

## Problem

When `--tsconfig` points at a file that can't be loaded (missing path, or a config that fails to resolve, e.g. `extends` a non-existent file), the error is thrown deep inside the child-process loader. Because the published bundle is minified and ships no source maps, Node prints the **entire bundled `get-tsconfig` parser source** as the offending code frame — ~23k characters of unreadable output before the actual message. On the ESM hooks path the throw could also leave the process hanging.

```
$ tsx --tsconfig ./nonexistent.json script.ts
.../register-*.cjs:7
`+"\t".repeat(t));var ne;(function(e){e.DEFAULT=...   // ~23,000 chars
...
Error: Cannot resolve tsconfig at path: .../nonexistent.json
```

## Fix

Validate the explicitly-passed `--tsconfig` in the **parent process** (in `run`, shared by both `tsx` and `tsx watch`) before spawning the child. On failure we print a concise, readable message and exit non-zero, so the unreadable minified stack frame (and the potential hang) never happens.

`loadTsconfig` now also throws clear, typed errors for the explicit-path branch (`Cannot find tsconfig at path:` / `Failed to read tsconfig at:`), which benefits programmatic API consumers too. The auto-detected (no `--tsconfig`) branch is unchanged and still silently ignored.

```
$ tsx --tsconfig ./nonexistent.json script.ts
Cannot find tsconfig at path: /abs/path/nonexistent.json
```

## Tests

Added two cases to `tests/specs/tsconfig.ts` (both package types) asserting a readable message **and** that the minified parser source is no longer dumped:

- missing tsconfig file
- unresolvable tsconfig (`extends` a non-existent file)

`pnpm type-check` and the `tsconfig` spec pass locally (18/18).
