### PR TITLE
chore: require cross-spawn 7.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
 		"chokidar": "^3.6.0",
 		"clean-pkg-json": "^1.2.0",
 		"cleye": "^1.3.2",
-		"cross-spawn": "^7.0.3",
+		"cross-spawn": "^7.0.6",
 		"es-module-lexer": "^1.5.4",
 		"execa": "^8.0.1",
 		"fs-fixture": "^2.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         specifier: ^1.3.2
         version: 1.3.2
       cross-spawn:
-        specifier: ^7.0.3
+        specifier: ^7.0.6
         version: 7.0.6
       es-module-lexer:
         specifier: ^1.5.4


### PR DESCRIPTION
## Problem

The source manifest still permits `cross-spawn` 7.0.3, which is affected by [GHSA-3xgq-45jj-v275](https://github.com/advisories/GHSA-3xgq-45jj-v275). Although the current lockfile already selects patched 7.0.6, the declared range allows vulnerable versions and keeps dependency audits concerned about future source installs.

## Changes

Raise the minimum `cross-spawn` version to 7.0.6. Because latest master already resolves 7.0.6 for every consumer, this changes only the manifest range and lockfile importer specifier; the installed package graph and bundled runtime code remain unchanged.
