### PR TITLE
fix: ignore pnpm node_modules dependencies in watch mode

### DIFF
--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -17,6 +17,18 @@ import {
 	log,
 } from './utils.js';
 
+const ignoredDependencyDirectories = new Set([
+	'node_modules',
+	'bower_components',
+	'vendor',
+]);
+
+const isInIgnoredDependencyDirectory = (
+	filePath: string,
+) => filePath.split(/[\\/]+/).some(
+	pathSegment => ignoredDependencyDirectories.has(pathSegment),
+);
+
 const flags = {
 	noCache: {
 		type: Boolean,
@@ -97,7 +109,10 @@ export const watchCommand = command({
 					: data.path
 			);
 
-			if (path.isAbsolute(dependencyPath)) {
+			if (
+				path.isAbsolute(dependencyPath)
+				&& !isInIgnoredDependencyDirectory(dependencyPath)
+			) {
 				watcher.add(dependencyPath);
 			}
 		}
@@ -216,6 +231,8 @@ export const watchCommand = command({
 			cwd: process.cwd(),
 			ignoreInitial: true,
 			ignored: [
+				isInIgnoredDependencyDirectory,
+
 				// Hidden directories like .git
 				'**/.*/**',
 

--- a/tests/specs/watch.ts
+++ b/tests/specs/watch.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import {
 	describe, test, onFinish, onTestFinish, onTestFail, expect, skip,
@@ -319,6 +321,72 @@ export const watch = ({ tsx }: NodeApis) => describe('watch', async () => {
 
 			tsxProcess.kill();
 
+			await tsxProcess;
+		}, 10_000);
+
+		test('pnpm dependency realpaths outside cwd', async () => {
+			if (process.platform === 'win32') {
+				skip('Uses POSIX symlinks to reproduce pnpm workspace layout');
+			}
+
+			const dependencyFile = 'node_modules/.pnpm/pnpm-dep@1.0.0/node_modules/pnpm-dep/index.js';
+			const entryFile = 'packages/app/index.js';
+			const negativeSignal = 'fail';
+
+			await using fixturePnpm = await createFixture({
+				[dependencyFile]: 'module.exports = { value: "dependency" };',
+				[entryFile]: `
+					const { value } = require('pnpm-dep');
+					console.log(value);
+					setInterval(() => {}, 1000);
+				`.trim(),
+			});
+
+			const appNodeModulesPath = path.join(fixturePnpm.path, 'packages/app/node_modules');
+			await fs.mkdir(appNodeModulesPath, { recursive: true });
+			await fs.symlink(
+				'../../../node_modules/.pnpm/pnpm-dep@1.0.0/node_modules/pnpm-dep',
+				path.join(appNodeModulesPath, 'pnpm-dep'),
+				'dir',
+			);
+
+			const tsxProcess = tsx(
+				[
+					'watch',
+					'--clear-screen=false',
+					'index.js',
+				],
+				path.join(fixturePnpm.path, 'packages/app'),
+			);
+
+			await expect(
+				processInteract(
+					tsxProcess.stdout!,
+					[
+						async ({ output }) => {
+							if (!output.includes('dependency\n')) {
+								return;
+							}
+
+							// Give watch mode time to process the runtime dependency path.
+							await setTimeout(1000);
+							await fixturePnpm.writeFile(dependencyFile, `module.exports = { value: "${negativeSignal}" };`);
+							return true;
+						},
+						({ output }) => {
+							if (
+								output.includes('Restarting...')
+								|| output.includes(negativeSignal)
+							) {
+								throw new Error('Unexpected re-run');
+							}
+						},
+					],
+					3000,
+				),
+			).rejects.toThrow('Timeout'); // Watch should not trigger for node_modules realpaths
+
+			tsxProcess.kill();
 			await tsxProcess;
 		}, 10_000);
 	});


### PR DESCRIPTION
## Summary

- Skip runtime dependency watch entries that resolve inside default third-party directories (`node_modules`, `bower_components`, `vendor`).
- Add the same predicate to chokidar's ignored paths so pnpm realpaths outside the current workspace package stay ignored.
- Add a regression test for a pnpm-style symlinked dependency whose real files live under `../../node_modules/.pnpm/...`.

Fixes #810

## Tests

- `pnpm type-check`
- `pnpm lint` (passes with existing warnings)
- `node ./dist/cli.mjs /tmp/oss-pr-pipeline/watch-runner.mts` (targeted watch suite; 12 passed)
- `pnpm test` attempted: the watch suite (including this regression) passed, but the full run failed in unrelated existing/environment-sensitive smoke named-export checks and PTY Ctrl+C signal tests in this container.
