### PR TITLE
fix: make named pipes compatible with Windows AppContainer

### DIFF
--- a/src/utils/ipc/get-pipe-path.ts
+++ b/src/utils/ipc/get-pipe-path.ts
@@ -6,7 +6,7 @@ export const getPipePath = (processId: number) => {
 	const pipePath = path.join(tmpdir, `${processId}.pipe`);
 	return (
 		isWindows
-			? `\\\\?\\pipe\\${pipePath}`
+			? `\\\\?\\pipe\\LOCAL\\${pipePath}` // LOCAL makes it AppContainer-compatible
 			: pipePath
 	);
 };


### PR DESCRIPTION
Inside Windows AppContainer, pipes must begin with \\pipe\LOCAL\. The kernel expands LOCAL to an AppContainer ID when inside an AppContainer. Outside an AppContainer, the kernel leaves LOCAL unchanged, which also works fine.
