### PR TITLE
fix(cli): run chained loaders after tsx

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -1,7 +1,71 @@
 import type { StdioOptions } from 'node:child_process';
+import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import spawn from 'cross-spawn';
 import { isFeatureSupported, moduleRegister } from './utils/node-features.js';
+
+const loaderFlags = new Set([
+	'--experimental-loader',
+	'--loader',
+]);
+
+const splitLoaderFlags = (
+	argv: string[],
+) => {
+	const loaderSpecifiers: string[] = [];
+	const rest: string[] = [];
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index]!;
+
+		if (argument === '--') {
+			rest.push(...argv.slice(index));
+			break;
+		}
+
+		if (loaderFlags.has(argument)) {
+			const specifier = argv[index + 1];
+			if (specifier) {
+				loaderSpecifiers.push(specifier);
+				index += 1;
+			} else {
+				rest.push(argument);
+			}
+			continue;
+		}
+
+		if (argument.startsWith('--loader=')) {
+			loaderSpecifiers.push(argument.slice('--loader='.length));
+			continue;
+		}
+
+		if (argument.startsWith('--experimental-loader=')) {
+			loaderSpecifiers.push(argument.slice('--experimental-loader='.length));
+			continue;
+		}
+
+		rest.push(argument);
+	}
+
+	return {
+		loaderSpecifiers,
+		rest,
+	};
+};
+
+const loaderRegisterImport = (
+	specifier: string,
+) => {
+	const registerSpecifier = path.isAbsolute(specifier)
+		? pathToFileURL(specifier).toString()
+		: specifier;
+
+	return `data:text/javascript,${encodeURIComponent(`import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register(${JSON.stringify(registerSpecifier)}, pathToFileURL('./'));
+`)}`;
+};
 
 export const run = (
 	argv: string[],
@@ -34,6 +98,11 @@ export const run = (
 	}
 
 	const shouldPatchRepl = argv.filter(flag => (flag !== '-i' && flag !== '--interactive')).length === 0;
+	const {
+		loaderSpecifiers,
+		rest,
+	} = splitLoaderFlags(argv);
+	const supportsModuleRegister = isFeatureSupported(moduleRegister);
 
 	return spawn(
 		process.execPath,
@@ -50,10 +119,20 @@ export const run = (
 					: []
 			),
 
-			isFeatureSupported(moduleRegister) ? '--import' : '--loader',
+			supportsModuleRegister ? '--import' : '--loader',
 			pathToFileURL(require.resolve('./loader.mjs')).toString(),
 
-			...argv,
+			...(
+				supportsModuleRegister
+					? [
+						...loaderSpecifiers.flatMap(specifier => [
+							'--import',
+							loaderRegisterImport(specifier),
+						]),
+						...rest,
+					]
+					: argv
+			),
 		],
 		{
 			stdio,

--- a/tests/specs/loaders.ts
+++ b/tests/specs/loaders.ts
@@ -57,6 +57,45 @@ export const loaders = (node: NodeApis) => describe('Loaders', () => {
 				},
 			});
 		});
+
+		test('passes transformed source to chained loaders', async () => {
+			await using fixture = await createFixture({
+				'package.json': createPackageJson({ type: 'module' }),
+				'entry.ts': `
+					import { test } from './another.ts';
+
+					console.log(test('ok'));
+					`,
+				'another.ts': `
+					export function test(input: string) {
+						return input;
+					}
+					`,
+				'inspect-loader.mjs': `
+					export const load = async (url, context, nextLoad) => {
+						const result = await nextLoad(url, context);
+
+						if (url.endsWith('/another.ts') && String(result.source).includes(': string')) {
+							throw new Error('loader received untransformed TypeScript');
+						}
+
+						return result;
+					};
+					`,
+			});
+
+			const result = await node.tsx(
+				[
+					'--loader',
+					pathToFileURL(fixture.getPath('inspect-loader.mjs')).toString(),
+					'./entry.ts',
+				],
+				fixture.path,
+			);
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toBe('ok');
+		});
 	});
 
 	describe('CJS patching', async () => {


### PR DESCRIPTION
## Summary

- register CLI `--loader` hooks through `module.register()` when available
- add a regression test for chained loaders receiving transformed TypeScript source

## Why

`tsx --loader import-in-the-middle/hook.mjs ./test.ts` currently lets the chained loader read raw TypeScript through `nextLoad()`, so loaders that parse JavaScript can fail on TypeScript syntax. Registering user loader hooks after tsx keeps them outside tsx, so `nextLoad()` returns transformed JavaScript.

Fixes #571.

## Validation

- red-before: `node dist/cli.mjs --loader import-in-the-middle/hook.mjs ./test.ts` failed with `SyntaxError: Unexpected token (1:26)`
- `corepack pnpm build`
- `node dist/cli.mjs --loader import-in-the-middle/hook.mjs ./test.ts` against a temporary `type: module` fixture
- focused loader spec through `tests/specs/loaders.ts`
- `corepack pnpm type-check`
- `corepack pnpm lint` (0 errors; existing warnings remain)
- `git diff --check`
- attempted `corepack pnpm test`; this environment hit unrelated current-Node smoke failures plus a disk-warning PTY timeout before the loader spec