### PR TITLE
fix: support dynamic import of Windows absolute paths

### DIFF
--- a/src/esm/hook/resolve.ts
+++ b/src/esm/hook/resolve.ts
@@ -104,6 +104,32 @@ const isCommonJsRequireContext = (
 	&& !context.conditions.includes('import')
 );
 
+// Drive letter (`C:\foo`, `C:/foo`) or UNC (`\\server\share`) paths
+const windowsAbsolutePathPattern = /^(?:[a-z]:[\\/]|\\\\)/i;
+
+/**
+ * Windows absolute paths cannot be parsed as URLs: the drive letter is
+ * parsed as the URL scheme (e.g. `C:` in `C:\foo`), so Node's ESM loader
+ * rejects them with ERR_UNSUPPORTED_ESM_URL_SCHEME
+ * https://github.com/privatenumber/tsx/issues/667
+ *
+ * CommonJS require() is excluded because Node's CommonJS resolver supports
+ * absolute paths but rejects file:// URLs
+ */
+const windowsPathToFileUrl = (
+	specifier: string,
+	context: ResolveHookContext,
+) => (
+	(
+		windowsAbsolutePathPattern.test(specifier)
+		// Filters out non-Windows platforms, where the pattern can match a relative path
+		&& path.isAbsolute(specifier)
+		&& !isCommonJsRequireContext(context)
+	)
+		? pathToFileURL(specifier).toString()
+		: specifier
+);
+
 /**
  * Maps a candidate specifier to a file path if it can be statted directly.
  * Returns undefined when existence can't be cheaply determined
@@ -687,7 +713,7 @@ export const createResolve = (
 		const [cleanSpecifier, query] = specifier.split('?');
 
 		const resolved = await resolveTsPaths(
-			cleanSpecifier,
+			windowsPathToFileUrl(cleanSpecifier, context),
 			context,
 			nextResolve,
 			hookData,
@@ -832,7 +858,7 @@ export const createResolveSync = (
 		const [cleanSpecifier, query] = specifier.split('?');
 
 		const resolved = resolveTsPathsSync(
-			cleanSpecifier,
+			windowsPathToFileUrl(cleanSpecifier, context),
 			context,
 			nextResolve,
 			hookData,

--- a/tests/specs/smoke.ts
+++ b/tests/specs/smoke.ts
@@ -706,6 +706,40 @@ export const smoke = ({ tsx, supports }: NodeApis) => describe('Smoke', () => {
 		expect(p.failed).toBe(false);
 	});
 
+	// https://github.com/privatenumber/tsx/issues/667
+	describe('dynamic import of an absolute path', () => {
+		// On Windows, absolute paths (e.g. `C:\foo`) fail to parse as URLs,
+		// misinterpreting the drive letter as the URL scheme
+		for (const [name, entryFile] of [
+			['from CommonJS', 'index.ts'],
+			['from ESM', 'index.mts'],
+		] as const) {
+			test(name, async () => {
+				await using fixture = await createFixture({
+					'package.json': createPackageJson({}),
+					[entryFile]: `
+					import path from 'node:path';
+
+					import(path.resolve('file.ts')).then((imported) => {
+						console.log(imported.value);
+					});
+					`,
+					'file.ts': "export const value = 'imported';",
+				});
+
+				const p = await tsx([entryFile], {
+					cwd: fixture.path,
+				});
+				onTestFail(() => {
+					console.log(p);
+				});
+				expect(p.failed).toBe(false);
+				expect(p.stdout).toBe('imported');
+				expect(p.stderr).toBe('');
+			});
+		}
+	});
+
 	if (supports.cjsInterop) {
 		test('mjs file can import named export from fake ESM even with --jitless', async () => {
 			await using fixture = await createFixture({


### PR DESCRIPTION
Fixes #667

Converts Windows absolute path specifiers (`C:\foo`, `C:/foo`, `\\server\share`) to `file://` URLs in the async and sync ESM resolve hooks, so `import(absolutePath)` works on Windows the same way it already does on POSIX under tsx.

## Problem

On Windows, a dynamic import of an absolute filesystem path fails:

```ts
import path from 'node:path';

await import(path.resolve('file.ts'));
// Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data,
// and node are supported by the default ESM loader. On Windows, absolute paths
// must be valid file:// URLs. Received protocol 'c:'
```

The specifier reaches `nextResolve()` unchanged, and the URL parser reads the drive letter as the URL scheme. The same code works under tsx on Linux/macOS, because a `/`-prefixed specifier is a valid path-based ESM specifier there — so tsx behavior is currently platform-inconsistent for the same source.

It also diverges from the compiled workflow tsx substitutes for: with `module: commonjs`, tsc down-levels `import()` to `require()`, which accepts absolute Windows paths. That's why the reproduction in #667 succeeds with `tsc && node` but fails under both `tsx` and `tsx watch` (both share the same ESM hooks).

Raw Node rejects these specifiers by design (#345, nodejs/node#34765), but tsx's resolver already accepts more path-like specifiers than Node (implicit extensions, directory indexes, tsconfig paths), and normalizing them here aligns Windows with existing tsx behavior on POSIX.

## Changes

- Detects drive-letter and UNC specifiers (combined with `path.isAbsolute()` so non-Windows platforms are unaffected) and converts them with `pathToFileURL()` before resolution, in both the async and sync resolve hooks.
- CommonJS `require()` contexts are excluded: Node's CommonJS resolver supports absolute paths natively but rejects `file://` URLs.
- Since the conversion happens before extension mapping, extensionless absolute paths (e.g. `import(path.resolve('file'))` targeting `file.ts`) also resolve, consistent with `file://` specifiers.
- Adds regression tests covering dynamic import of an absolute path from CommonJS and ESM entry points. They exercise the conversion on the windows-latest CI runner (`path.resolve()` produces a drive-letter path there) and pass on POSIX before and after this change.

## Verified on Windows 11, Node v22.14.0

Before (both `tsx` and `tsx watch`, using the reproduction from #667 with `await import(path.resolve(...))`):

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: ... Received protocol 'c:'
```

After: the import resolves and executes in both `tsx` and `tsx watch`; the new tests fail on master 3/3 and pass with this change 3/3.

## Limitations

- This intentionally diverges from raw Node ESM on Windows, which rejects absolute path specifiers. POSIX behavior is unchanged.
- Drive-relative specifiers without a separator (e.g. `C:file.ts`) are left as-is; they aren't absolute paths and keep failing the same way they do today.
