### PR TITLE
fix(watch): exit with 128 + signal number when interrupted

### DIFF
--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -270,8 +270,10 @@ export const watchCommand = command({
 				() => {},
 			);
 		} else {
+			// Exit with 128 + signal number, as done by Node.js & POSIX shells
+			// https://nodejs.org/api/process.html#exit-codes
 			// eslint-disable-next-line n/no-process-exit
-			process.exit(osConstants.signals[signal]);
+			process.exit(128 + osConstants.signals[signal]);
 		}
 	};
 

--- a/tests/specs/watch.ts
+++ b/tests/specs/watch.ts
@@ -401,6 +401,42 @@ export const watch = ({ tsx, path: nodePath }: NodeApis) => describe('watch', as
 		expect(all).toMatch(/start[\s\S]+end/);
 	}, 10_000);
 
+	await describe('Ctrl + C', async () => {
+		const CtrlC = '\u0003';
+
+		await test('exits with 130 when script already exited (issue #734)', async () => {
+			await using fixtureExited = await createFixture({
+				'index.js': 'console.log("READY")',
+			});
+
+			await using shell = ptyShell();
+
+			onTestFail(() => {
+				console.log({ stdout: shell.getOutput() });
+			});
+
+			await shell.waitForPrompt();
+			// PowerShell needs the call operator to run a quoted command
+			shell.type(`${isWindows ? '& ' : ''}"${nodePath}" "${tsxPath}" watch "${fixtureExited.getPath('index.js')}"`);
+
+			await shell.waitForLine(/READY/);
+
+			// Wait for the child process to exit so the watcher is idle
+			await setTimeout(1000);
+			shell.press(CtrlC);
+
+			await shell.waitForPrompt();
+			shell.type(`echo EXIT_CODE: ${isWindows ? '$LastExitCode' : '$?'}`);
+
+			await shell.waitForPrompt();
+
+			expect(await shell.close()).toMatch(/EXIT_CODE:\s+130/);
+		}, {
+			timeout: 15_000,
+			retry: 3,
+		});
+	});
+
 	await describe('help', () => {
 		test('shows help', async () => {
 			const tsxProcess = await tsx(['watch', '--help']);


### PR DESCRIPTION
Fixes #734

## Problem

Stopping `tsx watch` with Ctrl+C exits with code 2 whenever the watched script has already run to completion (the watcher is idle waiting for changes). On Windows, PowerShell & VS Code surface this as `terminated with exit code: 2`. #711 reports the same message and may share this root cause.

The watch-mode signal handler exits with the raw signal number ([src/watch/index.ts#L193-L196](https://github.com/privatenumber/tsx/blob/1dfad3720d73f722c5c9a1b7d4b6d1ec7bbcbc06/src/watch/index.ts#L193-L196)), while the non-watch CLI intentionally uses the `128 + signal` convention ([src/cli.ts#L120-L121](https://github.com/privatenumber/tsx/blob/1dfad3720d73f722c5c9a1b7d4b6d1ec7bbcbc06/src/cli.ts#L120-L121)) — which the existing `CLI › Signals › Ctrl + C` tests assert as 130.

This branch is hit consistently on Windows because the console delivers Ctrl+C to every attached process, so the child is usually gone before the parent's handler checks it. The same path is reachable on macOS/Linux whenever the script exited before Ctrl+C — it's just less visible because Unix shells don't report `$? = 2` as an error.

## Fix

Exit with `128 + signal number` (130 for `SIGINT`, 143 for `SIGTERM`), consistent with the non-watch CLI. The Ctrl+C-while-child-running path is unchanged (it still relays the child's exit code).

Verified in a real PowerShell (ConPTY) session on Windows 11, `tsx watch` on a script that logs and exits, then Ctrl+C:

| | `$LastExitCode` |
|---|---|
| `tsx` (non-watch, baseline) | 130 |
| `tsx watch` before | **2** |
| `tsx watch` after | 130 |

## Test

Added a PTY regression test (`watch › Ctrl + C`) mirroring the existing CLI Ctrl+C tests: run `tsx watch` on a script that exits immediately, press Ctrl+C once idle, and assert the shell reports exit code 130. It fails on master and passes with this change (verified on Windows PowerShell; the Unix branch checks `$?` in bash).

Notes:
- The test waits 1s after the script's output so the child has fully exited before Ctrl+C, and uses `retry: 3` like the other PTY signal tests.
- The typed command quotes the node/tsx paths (with PowerShell's `&` call operator) so the test also works when the node path contains spaces, e.g. a local `C:\Program Files` install.