### PR TITLE
fix: preserve listenerCount overload semantics

### DIFF
--- a/src/preflight.cts
+++ b/src/preflight.cts
@@ -37,8 +37,30 @@ const bindHiddenSignalsHandler = (
 
 	process.listenerCount = function (eventName) {
 		let count = Reflect.apply(listenerCount, this, arguments);
-		if (signals.includes(eventName as RelaySignals)) {
-			count -= 1;
+		const hiddenHandler = hiddenHandlers.get(eventName as RelaySignals);
+		const listener = arguments[1] as unknown;
+		const isAggregateCount = (
+			listenerCount.length === 1
+			|| arguments.length < 2
+			|| listener === undefined
+			|| listener === null
+		);
+		if (
+			hiddenHandler
+			&& (
+				isAggregateCount
+				|| listener === hiddenHandler
+			)
+		) {
+			const currentListeners: BaseEventListener[] = Reflect.apply(
+				listeners,
+				this,
+				[eventName],
+			);
+			const hiddenHandlerCount = currentListeners
+				.filter(currentListener => currentListener === hiddenHandler)
+				.length;
+			count -= hiddenHandlerCount;
 		}
 		return count;
 	};

--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -328,6 +328,7 @@ export const cli = (node: NodeApis) => describe('CLI', () => {
 					setImmediate(assertListenerCounts);
 					return;
 				}
+				console.log('aggregate = ' + process.listenerCount('SIGINT'));
 				console.log('specific = ' + process.listenerCount('SIGINT', handler));
 				console.log(
 					'invalid matches = '
@@ -478,7 +479,7 @@ export const cli = (node: NodeApis) => describe('CLI', () => {
 
 			const result = await tsxProcess;
 
-			expect(result.stdout).toBe('specific = 1\ninvalid matches = true\nafter removal = 0');
+			expect(result.stdout).toBe('aggregate = 1\nspecific = 1\ninvalid matches = true\nafter removal = 0');
 			expect(result.exitCode).toBe(0);
 		});
 

--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -317,6 +317,27 @@ export const cli = (node: NodeApis) => describe('CLI', () => {
 			console.log('process.listeners().length = ' + process.listeners('SIGINT').length);
 			console.log('process.listenerCount() = ' + process.listenerCount('SIGINT'));
 			`,
+			'hidden-signals-listener-count.js': `
+			const { EventEmitter } = require('node:events');
+			const handler = () => {};
+			const referenceEmitter = new EventEmitter();
+			referenceEmitter.on('SIGINT', handler);
+			process.on('SIGINT', handler);
+			const assertListenerCounts = () => {
+				if (process.rawListeners('SIGINT').length < 2) {
+					setImmediate(assertListenerCounts);
+					return;
+				}
+				console.log('specific = ' + process.listenerCount('SIGINT', handler));
+				console.log(
+					'invalid matches = '
+					+ (process.listenerCount('SIGINT', 'invalid') === referenceEmitter.listenerCount('SIGINT', 'invalid')),
+				);
+				process.removeAllListeners('SIGINT');
+				console.log('after removal = ' + process.listenerCount('SIGINT'));
+			};
+			assertListenerCounts();
+			`,
 		});
 		onFinish(async () => await fixture.rm());
 
@@ -447,6 +468,17 @@ export const cli = (node: NodeApis) => describe('CLI', () => {
 			const result = await tsxProcess;
 
 			expect(result.stdout).toBe('process.listeners().length = 0\nprocess.listenerCount() = 0');
+			expect(result.exitCode).toBe(0);
+		});
+
+		await test('Relay signal handler does not affect listenerCount overload', async () => {
+			const tsxProcess = tsx([
+				fixture.getPath('hidden-signals-listener-count.js'),
+			]);
+
+			const result = await tsxProcess;
+
+			expect(result.stdout).toBe('specific = 1\ninvalid matches = true\nafter removal = 0');
 			expect(result.exitCode).toBe(0);
 		});
 


### PR DESCRIPTION
Fixes #822

## Summary

- Preserve Node's listener-specific `process.listenerCount(eventName, listener)` semantics while keeping tsx's internal signal relay hidden.
- Subtract only relay listeners that are still registered, preventing negative counts after `removeAllListeners()`.
- Add a deterministic regression test covering specific listeners, invalid listener values, and relay removal.

## Root cause

The preflight wrapper unconditionally subtracted one for `SIGINT` and `SIGTERM`. That also changed listener-specific queries and assumed the hidden relay still existed.

## Validation

- Targeted signal tests on Node 24.15.0: 2 passed
- Targeted signal tests on Node 18.20.8: 2 passed
- Manual compatibility check on Node 18.0.0
- `pnpm type-check`
- Changed-file lint: 0 errors
