### PR TITLE
fix: obfuscate literal source map string

### DIFF
--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -1,6 +1,6 @@
 import type { Transformed } from './utils/transform/apply-transformers.js';
 
-const inlineSourceMapPrefix = '\n//# sourceMappingURL=data:application/json;base64,';
+const inlineSourceMapPrefix = 'sourceMappingURL=data:application/json;base64,';
 
 // TODO: Build this logic into inlineSourceMap
 // If undefined, assume sourcemap is enabled
@@ -10,6 +10,7 @@ export const inlineSourceMap = (
 	{ code, map }: Transformed,
 ) => (
 	code
+	+ '\n//# '
 	+ inlineSourceMapPrefix
 	+ Buffer.from(JSON.stringify(map), 'utf8').toString('base64')
 );


### PR DESCRIPTION
TL;DR: String containing `sourceMappingURL` causes bad sourcemap parsers to throw errors. A popular sourcemap parser lib is not maintained, so I propose a simple workaround fix on TSX's side.

# The Problem

The popular yet unmaintained [`convert-source-map`](https://www.npmjs.com/package/convert-source-map) library uses regex to find source maps in JS files :/  
So of course it does not check whether the source map comment is inside of a string literal or not.

This can cause tools such as vitest to accidentally try parsing TSX's minified source code as a base64 sourcemap (if TSX ends up in your error's stack trace). This leaves the user with confusing errors, due to the source map parser:

```
SyntaxError: Unexpected token '�', "�" is not valid JSON
 ❯ new Converter ../node_modules/convert-source-map/index.js:83:15
 ❯ Object.exports.fromComment ../node_modules/convert-source-map/index.js:181:10
 ❯ Object.exports.fromSource ../node_modules/convert-source-map/index.js:207:22
 ❯ extractSourcemapFromFile ../node_modules/@vitest/utils/dist/source-map/node.js:8:32
 ❯ Object.getSourceMap ../node_modules/vitest/dist/chunks/cli-api.24X8XwN1.js:12636:102
 ❯ ../node_modules/@vitest/utils/dist/source-map.js:391:37
 ❯ parseStacktrace ../node_modules/@vitest/utils/dist/source-map.js:387:16
 ❯ parseErrorStacktrace ../node_modules/@vitest/utils/dist/source-map.js:438:51
```

# The Fix

As a simple workaround, split the sourcemap string into two parts, so that the regex no longer finds the source map comment string in `tsx/dist/register-*`.

I've tested this fix with a minified build and verified that vitest now shows the correct error stack trace.

**I know this bug is not TSX's responsibility to fix,** but I hope that this workaround is accepted, since bad "parsers" are likely to stumble over TSX's source map snippet.

# Related Links

A similar fix was implemented [in the `babel/website` repo](https://github.com/babel/website/commit/d24c80ebd37708c7d50b335dae1e26c88da5ad8a) as well. See this [related convert-source-map issue](https://github.com/thlorenz/convert-source-map/issues/63) (untouched since 2019).
