### PR TITLE
fix(cli): allow async process.once() signal handlers to finish

### DIFF
--- a/src/preflight.cts
+++ b/src/preflight.cts
@@ -26,9 +26,7 @@ const bindHiddenSignalsHandler = (
 			}
 		};
 
-		/**
-		 * Prepend so this runs before user handlers.
-		 */
+		// Prepend so this runs before user handlers.
 		process.prependListener(signal, hiddenHandler);
 		hiddenHandlers.set(signal, hiddenHandler);
 	}

--- a/src/preflight.cts
+++ b/src/preflight.cts
@@ -26,7 +26,10 @@ const bindHiddenSignalsHandler = (
 			}
 		};
 
-		process.on(signal, hiddenHandler);
+		/**
+		 * Prepend so this runs before user handlers.
+		 */
+		process.prependListener(signal, hiddenHandler);
 		hiddenHandlers.set(signal, hiddenHandler);
 	}
 

--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -317,6 +317,16 @@ export const cli = (node: NodeApis) => describe('CLI', () => {
 			console.log('process.listeners().length = ' + process.listeners('SIGINT').length);
 			console.log('process.listenerCount() = ' + process.listenerCount('SIGINT'));
 			`,
+			'graceful-shutdown-once.js': `
+			process.once('SIGINT', async () => {
+				console.log('cleanup: started');
+				await new Promise(resolve => setTimeout(resolve, 100));
+				console.log('cleanup: finished');
+				process.exit(42);
+			});
+			setTimeout(() => {}, 1e5);
+			console.log('READY');
+			`,
 		});
 		onFinish(async () => await fixture.rm());
 
@@ -433,6 +443,59 @@ export const cli = (node: NodeApis) => describe('CLI', () => {
 
 				// This is the exit code I get from testing manually with Node
 				expect(result.exitCode).toBe(137);
+			}
+		}, {
+			timeout: 10_000,
+			retry: 3,
+		});
+
+		await test('Async process.once handler completes graceful shutdown', async () => {
+			const tsxProcess = tsx([
+				fixture.getPath('graceful-shutdown-once.js'),
+			]);
+
+			let stdout = '';
+			let tsxProcessResolved: Awaited<typeof tsxProcess> | undefined;
+
+			onTestFail(() => {
+				console.log({
+					tsxProcessResolved,
+					stdout,
+				});
+			});
+
+			// Accumulate stdout; send a single SIGINT once READY is seen.
+			tsxProcess.stdout!.setEncoding('utf8');
+			let sentSignal = isWindows; // Windows can't send POSIX signals
+			try {
+				for await (const [chunk] of on(tsxProcess.stdout!, 'data', {
+					close: ['end', 'close'],
+					signal: AbortSignal.timeout(10_000),
+				})) {
+					stdout += chunk;
+					if (!sentSignal && stdout.includes('READY')) {
+						sentSignal = true;
+						tsxProcess.kill('SIGINT', {
+							forceKillAfterTimeout: false,
+						});
+					}
+				}
+			} catch (error) {
+				if (!isAbortError(error)) {
+					throw error;
+				}
+			}
+
+			tsxProcessResolved = await tsxProcess;
+
+			if (isWindows) {
+				expect(stdout).toMatch('READY');
+			} else {
+				expect(tsxProcessResolved.exitCode).toBe(42);
+				expectMatchInOrder(stdout, [
+					'cleanup: started',
+					'cleanup: finished',
+				]);
 			}
 		}, {
 			timeout: 10_000,

--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -465,8 +465,10 @@ export const cli = (node: NodeApis) => describe('CLI', () => {
 			});
 
 			// Accumulate stdout; send a single SIGINT once READY is seen.
+			// On Windows this terminates the process unconditionally (no POSIX
+			// signal), so cleanup doesn't run there.
 			tsxProcess.stdout!.setEncoding('utf8');
-			let sentSignal = isWindows; // Windows can't send POSIX signals
+			let sentSignal = false;
 			try {
 				for await (const [chunk] of on(tsxProcess.stdout!, 'data', {
 					close: ['end', 'close'],
@@ -489,7 +491,7 @@ export const cli = (node: NodeApis) => describe('CLI', () => {
 			tsxProcessResolved = await tsxProcess;
 
 			if (isWindows) {
-				expect(stdout).toMatch('READY');
+				expect(stdout.trim()).toBe('READY');
 			} else {
 				expect(tsxProcessResolved.exitCode).toBe(42);
 				expectMatchInOrder(stdout, [


### PR DESCRIPTION
Fixes #826

## Problem

When an application run through the tsx CLI handles `SIGINT` or `SIGTERM` with `process.once()`, tsx can exit before asynchronous cleanup finishes.

tsx installs a hidden listener to relay signals to its parent process and emulate Node's default exit when no application listeners remain. That listener could run after an application's one-time listener. Node removes a one-time listener before invoking it, so tsx then saw no remaining application listeners and called `process.exit()`.

An application could start closing a database connection, then exit before its cleanup completes. The same handler completes when run with `node` or `node --import tsx`.

## Changes

tsx now runs its hidden relay listener before normal application listeners. It observes a one-time listener before Node removes it, allowing the handler to complete asynchronous cleanup and control the exit code.

The regression sends `SIGINT` to an asynchronous `process.once()` handler and confirms that cleanup finishes before exit. The test fails on the pre-fix implementation with exit code `130` and passes with exit code `42` after cleanup completes.

This covers ordinary `process.once()` registration. A handler added later with `process.prependOnceListener()` can still intentionally take precedence over the relay.
