### PR TITLE
fix: shim `import.meta` when tokens are split by comments or newlines

### DIFF
--- a/src/utils/transform/index.ts
+++ b/src/utils/transform/index.ts
@@ -8,6 +8,7 @@ import {
 	type TransformFailure,
 } from 'esbuild';
 import { sha1 } from '../sha1.js';
+import { parseEsm } from '../es-module-lexer.js';
 import { importMetaPathProperties, isFeatureSupported } from '../node-features.js';
 import {
 	version as transformDynamicImportVersion,
@@ -57,6 +58,22 @@ type TransformSyncOptions = TransformOptions & {
 	cjsBanner?: string;
 };
 
+const hasImportMeta = (
+	code: string,
+	filePath: string,
+) => {
+	if (!code.includes('import')) {
+		return false;
+	}
+
+	try {
+		return parseEsm(code, filePath)[0].some(imported => imported.d === -2);
+	} catch {
+		// Let esbuild report the source syntax error.
+		return true;
+	}
+};
+
 // Used by cjs-loader
 export const transformSync = (
 	code: string,
@@ -97,7 +114,7 @@ export const transformSync = (
 		esbuildOptions.format === 'cjs'
 		&& !filePath.endsWith('.cjs')
 		&& !filePath.endsWith('.cts')
-		&& code.includes('import')
+		&& hasImportMeta(code, filePath)
 	) {
 		esbuildOptions.define = {
 			...esbuildOptions.define,

--- a/src/utils/transform/index.ts
+++ b/src/utils/transform/index.ts
@@ -57,22 +57,6 @@ type TransformSyncOptions = TransformOptions & {
 	cjsBanner?: string;
 };
 
-/**
- * The `import.meta` tokens may be separated by whitespace or comments
- * (e.g. @babel/helper-define-polyfill-provider ships
- * `createRequire(import \/*::(_)*\/.meta.url)`), which the plain
- * substring fast-path misses. Over-matching here is harmless: a define
- * that never matches the AST emits nothing.
- *
- * @see https://github.com/babel/babel-polyfills/blob/%40babel/helper-define-polyfill-provider%401.0.0/packages/babel-helper-define-polyfill-provider/src/node/dependencies.ts#L5
- */
-const importMetaSyntax = /import(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\n]*\n)*\.(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\n]*\n)*meta\b/;
-
-const usesImportMeta = (code: string) => (
-	code.includes('import.meta')
-	|| importMetaSyntax.test(code)
-);
-
 // Used by cjs-loader
 export const transformSync = (
 	code: string,
@@ -113,7 +97,7 @@ export const transformSync = (
 		esbuildOptions.format === 'cjs'
 		&& !filePath.endsWith('.cjs')
 		&& !filePath.endsWith('.cts')
-		&& usesImportMeta(code)
+		&& code.includes('import')
 	) {
 		esbuildOptions.define = {
 			...esbuildOptions.define,

--- a/src/utils/transform/index.ts
+++ b/src/utils/transform/index.ts
@@ -57,6 +57,22 @@ type TransformSyncOptions = TransformOptions & {
 	cjsBanner?: string;
 };
 
+/**
+ * The `import.meta` tokens may be separated by whitespace or comments
+ * (e.g. @babel/helper-define-polyfill-provider ships
+ * `createRequire(import \/*::(_)*\/.meta.url)`), which the plain
+ * substring fast-path misses. Over-matching here is harmless: a define
+ * that never matches the AST emits nothing.
+ *
+ * @see https://github.com/babel/babel-polyfills/blob/%40babel/helper-define-polyfill-provider%401.0.0/packages/babel-helper-define-polyfill-provider/src/node/dependencies.ts#L5
+ */
+const importMetaSyntax = /import(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\n]*\n)*\.(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\n]*\n)*meta\b/;
+
+const usesImportMeta = (code: string) => (
+	code.includes('import.meta')
+	|| importMetaSyntax.test(code)
+);
+
 // Used by cjs-loader
 export const transformSync = (
 	code: string,
@@ -94,10 +110,10 @@ export const transformSync = (
 	};
 
 	if (
-		code.includes('import.meta')
-		&& esbuildOptions.format === 'cjs'
+		esbuildOptions.format === 'cjs'
 		&& !filePath.endsWith('.cjs')
 		&& !filePath.endsWith('.cts')
+		&& usesImportMeta(code)
 	) {
 		esbuildOptions.define = {
 			...esbuildOptions.define,

--- a/tests/specs/transform.ts
+++ b/tests/specs/transform.ts
@@ -100,6 +100,25 @@ export const transformSpec = () => describe('transform', () => {
 			expect(transformed.code).not.toContain('import_meta');
 		});
 
+		test('shims import.meta when tokens are split by comments or newlines', () => {
+			const transformed = transformSync(
+				outdent`
+				export const commented = import /*::(_)*/.meta.url;
+				export const newlined = import
+					.meta.url;
+				`,
+				'file.js',
+				{ format: 'cjs' },
+			);
+
+			const loaded = createFsRequire(Volume.fromJSON({
+				'/file.js': transformed.code,
+			}))('/file.js');
+
+			expect(loaded.commented).toMatch(/^file:\/\/\/.*\/file.js$/);
+			expect(loaded.newlined).toMatch(/^file:\/\/\/.*\/file.js$/);
+		});
+
 		test('supports import.meta object access', () => {
 			const transformed = transformSync(
 				`


### PR DESCRIPTION
## Problem

[#828](https://github.com/privatenumber/tsx/issues/828) found that valid `import.meta` expressions can include whitespace or comments between `import` and `.meta`. The previous text match missed those forms, leaving CommonJS-transformed modules without the metadata Node would normally provide.

## Changes

tsx now uses its existing `es-module-lexer` integration to identify `import.meta` in eligible CommonJS transforms. The regression test covers comment- and newline-separated forms.
