### PR TITLE
fix: ignore node_modules dependencies in watch mode

### DIFF
--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -19,6 +19,15 @@ import {
 	log,
 } from './utils.js';
 
+const ignoredDependencyDirectories = new Set([
+	'node_modules',
+	'bower_components',
+	'vendor',
+]);
+const isInIgnoredDependencyDirectory = (filePath: string) => filePath
+	.split(/[\\/]+/)
+	.some(pathSegment => ignoredDependencyDirectories.has(pathSegment));
+
 const flags = {
 	noCache: {
 		type: Boolean,
@@ -163,7 +172,10 @@ export const watchCommand = command({
 					: data.path
 			);
 
-			if (path.isAbsolute(dependencyPath)) {
+			if (
+				path.isAbsolute(dependencyPath)
+				&& !isInIgnoredDependencyDirectory(dependencyPath)
+			) {
 				if (exactNegatedIncludes.has(getPathKey(dependencyPath))) {
 					if (!dependencyOverrideWatcher) {
 						dependencyOverrideWatcher = new FSWatcher({

--- a/tests/specs/watch.ts
+++ b/tests/specs/watch.ts
@@ -592,6 +592,48 @@ export const watch = ({ tsx, path: nodePath }: NodeApis) => describe('watch', as
 
 			await tsxProcess;
 		}, 10_000);
+
+		test('ignores pnpm dependency realpaths outside cwd', async () => {
+			const dependencyPath = 'node_modules/.pnpm/pnpm-dep@1.0.0/node_modules/pnpm-dep';
+			const dependencyFile = `${dependencyPath}/index.js`;
+
+			// Mock the dependency files
+			await using fixturePnpm = await createFixture({
+				[dependencyFile]: 'module.exports = "dependency";',
+				'packages/app/index.js': `
+					console.log(require('pnpm-dep'));
+					setInterval(() => {}, 1000);
+				`.trim(),
+				'packages/app/node_modules/pnpm-dep': ({ getPath, symlink }) => symlink(
+					getPath(dependencyPath),
+					'junction',
+				),
+			});
+			const appPath = fixturePnpm.getPath('packages/app');
+
+			// Start tsx
+			const tsxProcess = tsx(
+				['watch', '--clear-screen=false', 'index.js'],
+				appPath,
+			);
+
+			// Monitor healthy startup
+			await processInteract(
+				tsxProcess.stdout!,
+				[({ output }) => output.includes('dependency\n')],
+				5000,
+			);
+
+			// Rewrite the node_modules dependency
+			await setTimeout(1000);
+			await fixturePnpm.writeFile(dependencyFile, 'module.exports = "updated";');
+			await setTimeout(2000);
+			tsxProcess.kill();
+
+			// Make sure tsx has not restarted
+			const { all } = await tsxProcess;
+			expect(all).not.toMatch('Restarting...');
+		}, 10_000);
 	});
 
 	await test('strips internal watch flags from child argv', async () => {


### PR DESCRIPTION
## Summary of changes

Skip runtime dependencies inside ignored third-party directories before adding them to the watcher. This stops tsx from exhausting file descriptors with redundant watchers when `node_modules` packages are symlinked, similar to how pnpm resolves cached dependencies.

Adds regression coverage for symlinked `node_modules`. Follows the approach proposed in #816, updated for the current watch implementation.

Fixes #810