### PR TITLE
fix: preserve strict mode when transforming ESM to CommonJS

### DIFF
--- a/src/utils/transform/index.ts
+++ b/src/utils/transform/index.ts
@@ -58,19 +58,54 @@ type TransformSyncOptions = TransformOptions & {
 	cjsBanner?: string;
 };
 
-const hasImportMeta = (
+/**
+ * ES modules are always strict, but Node compiles the transformed output inside
+ * a sloppy CommonJS wrapper. The directive opens the banner's IIFE so the module
+ * keeps the mode it was authored against.
+ * https://tc39.es/ecma262/#sec-strict-mode-code
+ */
+const useStrictDirective = '"use strict";';
+
+const commonJsExtensions = ['.cjs', '.cts'];
+const esmExtensions = ['.mjs', '.mts'];
+
+/**
+ * `isEsm` mirrors Node's module syntax detection, plus `.mjs` & `.mts`, which
+ * are ES modules regardless of the syntax they contain. `.cjs` & `.cts` are
+ * CommonJS on the same terms, so they're not parsed at all.
+ *
+ * Both facts are read from one parse because the lexer already runs on every
+ * CommonJS transform.
+ */
+const parseModuleSyntax = (
 	code: string,
 	filePath: string,
 ) => {
-	if (!code.includes('import')) {
-		return false;
+	if (commonJsExtensions.some(extension => filePath.endsWith(extension))) {
+		return;
+	}
+
+	const isEsmExtension = esmExtensions.some(extension => filePath.endsWith(extension));
+
+	if (!code.includes('import') && !code.includes('export')) {
+		return {
+			isEsm: isEsmExtension,
+			hasImportMeta: false,
+		};
 	}
 
 	try {
-		return parseEsm(code, filePath)[0].some(imported => imported.d === -2);
+		const parsed = parseEsm(code, filePath);
+		return {
+			isEsm: isEsmExtension || parsed[3],
+			hasImportMeta: parsed[0].some(imported => imported.d === -2),
+		};
 	} catch {
 		// Let esbuild report the source syntax error.
-		return true;
+		return {
+			isEsm: true,
+			hasImportMeta: true,
+		};
 	}
 };
 
@@ -97,11 +132,18 @@ export const transformSync = (
 		cjsBanner,
 		...extendOptionsWithoutCjsBanner
 	} = extendOptions ?? {};
+
+	const moduleSyntax = (
+		(extendOptionsWithoutCjsBanner.format ?? 'cjs') === 'cjs'
+			? parseModuleSyntax(code, filePath)
+			: undefined
+	);
+
 	const esbuildOptions: TransformOptions = {
 		...cacheConfig,
 		format: 'cjs',
 		sourcefile: filePath,
-		banner: `__filename=${JSON.stringify(filePath)};(()=>{${cjsBanner ?? ''}`,
+		banner: `__filename=${JSON.stringify(filePath)};(()=>{${moduleSyntax?.isEsm ? useStrictDirective : ''}${cjsBanner ?? ''}`,
 		footer: '})()',
 
 		// CJS Annotations for Node. Used by ESM loader for CJS interop
@@ -110,12 +152,7 @@ export const transformSync = (
 		...extendOptionsWithoutCjsBanner,
 	};
 
-	if (
-		esbuildOptions.format === 'cjs'
-		&& !filePath.endsWith('.cjs')
-		&& !filePath.endsWith('.cts')
-		&& hasImportMeta(code, filePath)
-	) {
+	if (moduleSyntax?.hasImportMeta) {
 		esbuildOptions.define = {
 			...esbuildOptions.define,
 			'import.meta': JSON.stringify(getImportMeta(filePath, url)),

--- a/tests/specs/commonjs-mode-contracts.ts
+++ b/tests/specs/commonjs-mode-contracts.ts
@@ -194,6 +194,129 @@ export const commonJsModeContracts = (node: NodeApis) => describe('CommonJS mode
 		}
 	});
 
+	// A file written with ESM syntax is always strict, and the module that
+	// happens to import it cannot change that. tsx transforms these files to
+	// CommonJS, whose wrapper is sloppy, so the mode has to be restored.
+	// https://github.com/privatenumber/tsx/issues/676
+	describe('strict mode', () => {
+		// Sloppy mode substitutes the global object for an undefined `this`,
+		// and silently creates a global instead of throwing on an assignment
+		// to an undeclared binding.
+		const reportMode = outdent`
+		let assignedUndeclared = true;
+		try {
+			undeclaredBinding = 1;
+		} catch {
+			assignedUndeclared = false;
+		}
+
+		console.log(JSON.stringify({
+			isStrict: (function () { return this === undefined; })(),
+			assignedUndeclared,
+		}));
+		`;
+
+		const strictExpectation = {
+			isStrict: true,
+			assignedUndeclared: false,
+		};
+
+		test('module imported by a CommonJS-classified file is strict', async () => {
+			for (const { label, packageJson } of commonJsModes) {
+				await using fixture = await createFixture({
+					'package.json': createPackageJson(packageJson),
+					'index.ts': outdent`
+						import './imported.ts';
+					`,
+					'imported.ts': outdent`
+						export const marker = 'imported';
+
+						${reportMode}
+					`,
+				});
+
+				const result = await node.tsx(['index.ts'], fixture.path);
+				onTestFail(() => {
+					console.log(label, result);
+				});
+
+				expect(result.failed).toBe(false);
+				expect(JSON.parse(result.stdout)).toEqual(strictExpectation);
+			}
+		});
+
+		test('esm syntax entrypoint is strict', async () => {
+			for (const { label, packageJson } of commonJsModes) {
+				await using fixture = await createFixture({
+					'package.json': createPackageJson(packageJson),
+					'index.ts': outdent`
+						export const marker = 'entry';
+
+						${reportMode}
+					`,
+				});
+
+				const result = await node.tsx(['index.ts'], fixture.path);
+				onTestFail(() => {
+					console.log(label, result);
+				});
+
+				expect(result.failed).toBe(false);
+				expect(JSON.parse(result.stdout)).toEqual(strictExpectation);
+			}
+		});
+
+		test('CommonJS entrypoint stays sloppy', async () => {
+			for (const { label, packageJson } of commonJsModes) {
+				await using fixture = await createFixture({
+					'package.json': createPackageJson(packageJson),
+					'index.ts': outdent`
+						module.exports = require('./dep.cjs');
+
+						${reportMode}
+					`,
+					'dep.cjs': 'module.exports = { loaded: true };',
+				});
+
+				const result = await node.tsx(['index.ts'], fixture.path);
+				onTestFail(() => {
+					console.log(label, result);
+				});
+
+				expect(result.failed).toBe(false);
+				expect(JSON.parse(result.stdout)).toEqual({
+					isStrict: false,
+					assignedUndeclared: true,
+				});
+			}
+		});
+
+		test('required .cjs dependency stays sloppy', async () => {
+			for (const { label, packageJson } of commonJsModes) {
+				await using fixture = await createFixture({
+					'package.json': createPackageJson(packageJson),
+					'index.ts': outdent`
+						export const marker = 'entry';
+
+						require('./dep.cjs');
+					`,
+					'dep.cjs': reportMode,
+				});
+
+				const result = await node.tsx(['index.ts'], fixture.path);
+				onTestFail(() => {
+					console.log(label, result);
+				});
+
+				expect(result.failed).toBe(false);
+				expect(JSON.parse(result.stdout)).toEqual({
+					isStrict: false,
+					assignedUndeclared: true,
+				});
+			}
+		});
+	});
+
 	// tsx is intentionally more lenient than Node for ambiguous-`type` and
 	// explicit `"commonjs"` packages: a `.js`/`.ts` file that mixes ESM
 	// `import`/`export` syntax with explicit `require()` calls still runs,

--- a/tests/specs/transform.ts
+++ b/tests/specs/transform.ts
@@ -191,6 +191,61 @@ export const transformSpec = () => describe('transform', () => {
 			expect(dynamicImport.code).toMatch('.href).then');
 		});
 
+		// ES modules are always strict, so the transformed CommonJS output has
+		// to declare the mode Node's module wrapper doesn't provide.
+		// https://github.com/privatenumber/tsx/issues/676
+		describe('strict mode', () => {
+			// Sloppy mode substitutes the global object for an undefined `this`
+			const isStrictExpression = '(function () { return this === undefined; })()';
+
+			const requireTransformed = (
+				fileName: string,
+				code: string,
+			) => {
+				const transformed = transformSync(code, fileName, { format: 'cjs' });
+				const fsRequire = createFsRequire(Volume.fromJSON({
+					[`/${fileName}`]: transformed.code,
+				}));
+				return fsRequire(`/${fileName}`) as { isStrict: boolean };
+			};
+
+			test('esm syntax is strict', () => {
+				const loaded = requireTransformed(
+					'file.js',
+					`export const isStrict = ${isStrictExpression};`,
+				);
+
+				expect(loaded.isStrict).toBe(true);
+			});
+
+			test('commonjs syntax stays sloppy', () => {
+				const loaded = requireTransformed(
+					'file.js',
+					`exports.isStrict = ${isStrictExpression};`,
+				);
+
+				expect(loaded.isStrict).toBe(false);
+			});
+
+			test('cts stays sloppy despite esm syntax', () => {
+				const loaded = requireTransformed(
+					'file.cts',
+					`export const isStrict = ${isStrictExpression};`,
+				);
+
+				expect(loaded.isStrict).toBe(false);
+			});
+
+			test('mjs is strict without esm syntax', () => {
+				const loaded = requireTransformed(
+					'file.mjs',
+					`exports.isStrict = ${isStrictExpression};`,
+				);
+
+				expect(loaded.isStrict).toBe(true);
+			});
+		});
+
 		test('sourcemap file', () => {
 			const fileName = 'file.mts';
 			const transformed = transformSync(


### PR DESCRIPTION
Fixes #676

`transformSync` wraps every CommonJS transform in `(()=>{ ... })()`, and Node compiles the result inside its CommonJS module wrapper, which is sloppy. Neither the banner nor esbuild's output opens with a directive prologue, so a module written in ESM syntax loses the strictness it was written against, and which mode it gets depends on the file that imported it. Beyond the undeclared assignment in the report, this also changes `this` in plain function calls, block-scoped function declarations, duplicate parameter names, and assignments to non-writable properties.

Open the banner's IIFE with the directive when the source is an ES module:

```js
banner: `__filename=${JSON.stringify(filePath)};(()=>{${moduleSyntax?.isEsm ? '"use strict";' : ''}${cjsBanner ?? ''}`,
```

The IIFE has no parameters, so the directive is a valid prologue, and the banner stays on line one so source maps are unaffected. The banner feeds the transform cache key, so cached output does not go stale.

It is gated because adding the directive unconditionally would change how genuine CommonJS files run, and sloppy is the correct mode for them. `.mjs`/`.mts` are ESM and `.cjs`/`.cts` are CommonJS whatever they contain; everything else is decided by es-module-lexer's module syntax detection, the same signal tsx already uses to decide whether a `.js` file needs transforming.

Two deliberate divergences from Node:

- `.cjs` and `.cts` stay sloppy even when written with `import`/`export`. Node treats them as CommonJS and the CJS loader's existing `isEsmSyntax` check already excluded them.
- A `.ts` file whose only module syntax is `import type` now gets the directive. Node's detector runs after type stripping and would call it CommonJS, but `tsc` emits `"use strict"` for it, since any top-level import makes the file a module. Matching `tsc` seemed the better of the two.

The module type and the existing `import.meta` check now read from one lexer parse instead of two, so this adds no parse to the transform path.

Strict mode against what Node reports for the same file:

| File | Node | tsx before | tsx after |
| --- | --- | --- | --- |
| `probe.mjs` / `probe.mts` | strict | strict | strict |
| `probe.js` / `probe.ts` with ESM syntax | strict | sloppy | strict |
| `probe-cjs.js` / `.cjs` / `.cts` | sloppy | sloppy | sloppy |

Four unit tests in `tests/specs/transform.ts` (ESM syntax, plain CommonJS, `.cts` written with ESM syntax, `.mjs` written without it) and four end-to-end in `tests/specs/commonjs-mode-contracts.ts`, each run under both an omitted `type` field and an explicit `"commonjs"`. The two asserting strict mode fail on `master`; the two asserting sloppy pass either way and pin behavior that must not move.

`pnpm lint` (no new errors; new warnings are the `onTestFail` console calls this file already uses throughout), `pnpm type-check`, and `CI=1 pnpm test`: 462 passing on Node 18.20.8, 20.20.2, 21.7.3, 22.22.3, 24.14.1, 25.9.0 and 26.1.0.
